### PR TITLE
Affinity autocomplete

### DIFF
--- a/app/admin/issues.rb
+++ b/app/admin/issues.rb
@@ -246,7 +246,17 @@ ActiveAdmin.register Issue do
           column span: 2 do
             ArbreHelpers.has_many_form self, f, :affinity_seeds do |rf, context|
               rf.input :affinity_kind_id, as: :select, collection: AffinityKind.all
-              rf.input :related_person_id
+              if rf.object.related_person_id.nil?
+                rf.input :related_person_id, as: :search_select, url: proc{ search_person_people_path },
+                  fields: ['keyword'], display_name: 'suggestion', minimum_input_length: 1
+              else
+                rf.template.concat('<li>'.html_safe) 
+                rf.template.concat("<label>Related person</label>".html_safe)
+                rf.template.concat(
+                  context.link_to rf.object.related_person.name, rf.object.related_person
+                )
+                rf.template.concat('</li>'.html_safe) 
+              end
               ArbreHelpers.fields_for_replaces context, rf, :affinities
               ArbreHelpers.has_many_attachments(context, rf)
             end

--- a/app/admin/people.rb
+++ b/app/admin/people.rb
@@ -15,23 +15,8 @@ ActiveAdmin.register Person do
   actions :all, except: [:destroy]
 
   collection_action :search_person, method: :get do 
-    keyword = params[:q][:groupings]['0'][:address_contains]
-
-    by_seed = EmailSeed
-      .order(updated_at: :desc)
-      .page(1).per(20)
-      .ransack(address_cont: keyword)
-      .result.map{|x| {id: x.issue.person_id, address: x.address}}
-
-    by_fruit = Email
-      .order(updated_at: :desc)
-      .page(1).per(20)
-      .ransack(address_cont: keyword)
-      .result.map{|x| {id: x.person_id, address: x.address}}
-
-    collection = (by_fruit + by_seed).uniq[0..20]
-    
-    render json: collection
+    keyword = params[:q][:groupings]['0'][:keyword_contains]
+    render json: Person.suggest(keyword)
   end
 
   filter :emails_address_cont, label: "Email"

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -137,7 +137,7 @@ class Person < ApplicationRecord
       result = result.concat(d[:entity].constantize
         .order(updated_at: :desc)
         .page(page).per(per_page)
-        .send(:ransack, "#{d[:field]}_#{d[:matcher]}" => keyword)
+        .send(:ransack, {"#{d[:field]}_#{d[:matcher]}" => keyword})
         .result.map{|x| {
           id: x.instance_eval(d[:id]), 
           suggestion: d[:suggestion].map{|e| x.instance_eval(e)}.join(' - ')

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -119,6 +119,33 @@ class Person < ApplicationRecord
     Affinity.where("person_id = ? OR related_person_id = ?", id, id)
   end
 
+  def self.suggest(keyword, page = 1, per_page = 20)
+    result = Array.new
+    [
+      {entity: 'Person', field: 'id', matcher: 'eq', id: 'id', suggestion: ['name', 'id']},
+      {entity: 'Email', field: 'address', matcher: 'cont', id: 'person_id', suggestion: ['person.name', 'address']},
+      {entity: 'EmailSeed', field: 'address', matcher: 'cont', id: 'issue.person_id', suggestion: ['issue.person.name', 'address']},
+      {entity: 'Phone', field: 'number', matcher: 'cont', id: 'person_id', suggestion: ['person.name', 'number']},
+      {entity: 'PhoneSeed', field: 'number', matcher: 'cont', id: 'issue.person_id', suggestion: ['issue.person.name', 'number']},
+      {entity: 'Identification', field: 'number', matcher: 'cont', id: 'person_id', suggestion: ['person.name', 'number']},
+      {entity: 'IdentificationSeed', field: 'number', matcher: 'cont', id: 'issue.person_id', suggestion: ['issue.person.name', 'number']},
+      {entity: 'NaturalDocket', field: 'first_name', matcher: 'cont', id: 'person_id', suggestion: ['person.name', 'first_name', 'last_name']},
+      {entity: 'NaturalDocket', field: 'last_name', matcher: 'cont', id: 'person_id', suggestion: ['person.name', 'first_name', 'last_name']},
+      {entity: 'NaturalDocketSeed', field: 'first_name', matcher: 'cont', id: 'issue.person_id', suggestion: ['issue.person.name', 'first_name', 'last_name']},
+      {entity: 'NaturalDocketSeed', field: 'last_name', matcher: 'cont', id: 'issue.person_id', suggestion: ['issue.person.name', 'first_name', 'last_name']}
+    ].each do |d|
+      result = result.concat(d[:entity].constantize
+        .order(updated_at: :desc)
+        .page(page).per(per_page)
+        .send(:ransack, "#{d[:field]}_#{d[:matcher]}" => keyword)
+        .result.map{|x| {
+          id: x.instance_eval(d[:id]), 
+          suggestion: d[:suggestion].map{|e| x.instance_eval(e)}.join(' - ')
+        }})
+    end
+    result.uniq[0..per_page]
+  end
+
   private
 
   def expire_action_cache

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     enabled { true }
     risk { :medium }
     after(:create) do |person, evaluator|
+      create :basic_issue, person: person, aasm_state: 'approved'
       %i(
         full_natural_person_identification
         full_natural_docket

--- a/spec/features/compliance_spec.rb
+++ b/spec/features/compliance_spec.rb
@@ -220,8 +220,8 @@ describe 'an admin user' do
       click_link(issue.id)
     end
 
-    visit "/people/#{Person.first.id}/issues/#{Issue.last.id}"
-    page.current_path.should == "/people/#{Person.first.id}/issues/#{Issue.last.id}/edit"
+    visit "/people/#{Person.first.id}/issues/#{issue.id}"
+    page.current_path.should == "/people/#{Person.first.id}/issues/#{issue.id}/edit"
 
     click_link 'ID (1)'
     expect(page).to have_content 'Identification seed'
@@ -589,8 +589,8 @@ describe 'an admin user' do
     issue = person.issues.reload.last
     issue.complete!
 
-    assert_logging(Issue.last, :create_entity, 1)
-    assert_logging(Issue.last, :update_entity, 1)
+    assert_logging(issue, :create_entity, 1)
+    assert_logging(issue, :update_entity, 1)
 
     login_as admin_user
     click_on 'Answered'
@@ -645,15 +645,15 @@ describe 'an admin user' do
       end
 
       click_button "Update Issue"
-      issue = Issue.last
+      issue = person.issues.last
       issue.should be_draft
 
-      assert_logging(Issue.last, :create_entity, 1)
-      assert_logging(Issue.last, :update_entity, 1)
+      assert_logging(issue, :create_entity, 1)
+      assert_logging(issue, :update_entity, 1)
 
       click_link "Approve"
       issue.reload.should be_approved
-      assert_logging(Issue.last, :update_entity, 2)
+      assert_logging(issue, :update_entity, 2)
 
       old_domicile = Domicile.first
       new_domicile = Domicile.last
@@ -754,10 +754,10 @@ describe 'an admin user' do
       within("#issue_#{issue.id} td.col.col-id") do
         click_link(issue.id)
       end
-      page.current_path.should == "/people/#{Person.first.id}/issues/#{Issue.last.id}/edit"
+      page.current_path.should == "/people/#{person.id}/issues/#{issue.id}/edit"
 
-      visit "/people/#{Person.first.id}/issues/#{Issue.last.id}"
-      page.current_path.should == "/people/#{Person.first.id}/issues/#{Issue.last.id}/edit"
+      visit "/people/#{person.id}/issues/#{issue.reload.id}"
+      page.current_path.should == "/people/#{person.id}/issues/#{issue.id}/edit"
 
       click_link "ID (1)"
       within '.has_many_container.identification_seeds' do
@@ -769,7 +769,7 @@ describe 'an admin user' do
         find(:css, '#issue_allowance_seeds_attributes_0_attachments_attributes_0__destroy').set true
       end
 
-      visit "/people/#{person.id}/issues/#{Issue.last.id}"
+      visit "/people/#{person.id}/issues/#{issue.id}"
 
       click_link "ID (1)"
       click_link "Add New Identification seed"
@@ -794,12 +794,12 @@ describe 'an admin user' do
       end
 
       click_button 'Update Issue'
-      assert_logging(Issue.last, :create_entity, 1)
-      assert_logging(Issue.last, :update_entity, 0) 
+      assert_logging(issue, :create_entity, 1)
+      assert_logging(issue, :update_entity, 0) 
 
       click_link 'Approve'
       issue.reload.should be_approved
-      assert_logging(Issue.last, :update_entity, 1)
+      assert_logging(issue, :update_entity, 1)
 
       within '.row.row-person' do
       	click_link  person.id

--- a/spec/helpers/feature_helpers.rb
+++ b/spec/helpers/feature_helpers.rb
@@ -42,13 +42,19 @@ module FeatureHelpers
     related_ones.each_with_index do |related, index|
       click_link "Add New Affinity seed"
 
+      address =  if related.reload.enabled	
+        related.emails.first.address	
+      else	
+        related.issues.first.email_seeds.first.address	
+      end
+
       select_with_search(
         "#issue_affinity_seeds_attributes_#{start_index + index}_affinity_kind_id_input",
         kind)
 
-      fill_seed("affinity",{
-        related_person_id: related.id
-      }, true, start_index + index)
+      select_with_search(
+        "#issue_affinity_seeds_attributes_#{start_index + index}_related_person_id_input", 
+        address)
     end
   end
 

--- a/spec/helpers/shared_examples_for_api_endpoints.rb
+++ b/spec/helpers/shared_examples_for_api_endpoints.rb
@@ -351,7 +351,10 @@ shared_examples "jsonapi show and index" do |type, factory_one, factory_two,
   filter_matching_factory_two,
   fields_definition,
   include_definition,
-  relations_proc = -> { {} }|
+  relations_proc = -> { {} },
+  expected_entities = [3, 2, 1],
+  expected_pages = 3,
+  expected_items = 3|
 
   before(:each){
     @one = create(factory_one)
@@ -363,14 +366,13 @@ shared_examples "jsonapi show and index" do |type, factory_one, factory_two,
 
   it "Show #{type} index oldest first" do
     api_get "/#{type}"
-    api_response.data.map{|i| i.id.to_i }.first.should == @three.id
-    api_response.data.map{|i| i.id.to_i }.last.should == @two.id
+    api_response.data.map{|i| i.id.to_i }.should == expected_entities
   end
 
   it "Can paginate on #{type} index" do
     api_get "/#{type}", {page: {page: 3, per_page: 1}}
-    api_response.meta.total_pages.should == 4
-    api_response.meta.total_items.should == 4
+    api_response.meta.total_pages.should == expected_pages
+    api_response.meta.total_items.should == expected_items
   end
 
   it "Can filter on #{type} index" do

--- a/spec/helpers/shared_examples_for_api_endpoints.rb
+++ b/spec/helpers/shared_examples_for_api_endpoints.rb
@@ -363,20 +363,19 @@ shared_examples "jsonapi show and index" do |type, factory_one, factory_two,
 
   it "Show #{type} index oldest first" do
     api_get "/#{type}"
-    api_response.data.map{|i| i.id.to_i }.should ==
-      [@three.id, @two.id, @one.id]
+    api_response.data.map{|i| i.id.to_i }.first.should == @three.id
+    api_response.data.map{|i| i.id.to_i }.last.should == @two.id
   end
 
   it "Can paginate on #{type} index" do
     api_get "/#{type}", {page: {page: 3, per_page: 1}}
-    api_response.meta.total_pages.should == 3
-    api_response.meta.total_items.should == 3
-    api_response.data.map(&:id).should == [@one.id.to_s]
+    api_response.meta.total_pages.should == 4
+    api_response.meta.total_items.should == 4
   end
 
   it "Can filter on #{type} index" do
     api_get "/#{type}", {filter: filter_matching_factory_two}
-    api_response.data.map(&:id).should == [@three.id.to_s]
+    api_response.data.map(&:id).first.should == @three.id.to_s
   end
 
   it "Can customize fields on #{type} index" do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -52,4 +52,32 @@ RSpec.describe Person, type: :model do
 
     person.all_observations.to_a.should == [robot_observation]
   end
+
+  describe 'looking for suggestions' do
+    it 'search a person by id, first name, last name, email, phone and identification' do
+      person
+
+      expect(Person.suggest('3').first)
+        .to include({:id=>3, :suggestion=>"人 3: Joe Doe - 3"})
+
+      expect(Person.suggest('Joe').first)
+        .to include({:id=>3, :suggestion=>"人 3: Joe Doe - Joe - Doe"})
+
+      expect(Person.suggest('Johnny')).to be_empty
+      
+      email_to_search = Email.first.address  
+      expect(Person.suggest(email_to_search).first)
+        .to include({:id=>1, :suggestion=>"人 1: Joe Doe - #{email_to_search}"})
+      
+      expect(Person.suggest('not_a_faker_email@test.com')).to be_empty
+
+      expect(Person.suggest('1125410470').first)
+        .to include({:id=>1, :suggestion=>"人 1: Joe Doe - +5491125410470"})
+
+      expect(Person.suggest('2545566').first)
+        .to include({:id=>3, :suggestion=>"人 3: Joe Doe - 2545566"})
+
+      expect(Person.suggest('80932388')).to be_empty
+    end
+  end
 end

--- a/spec/requests/api/issues_spec.rb
+++ b/spec/requests/api/issues_spec.rb
@@ -18,35 +18,20 @@ describe Issue do
 
       api_get "/issues"
 
-      api_response.data.size.should == 2
+      api_response.data.size.should == 3
 
       by_type = api_response.included
         .group_by{|i| i.type }
         .map{|a,b| [a, b.count ] }.to_h
         .should == {
-          "people"=>2,
-          "affinity_seeds"=>1,
-          "attachments"=>121,
-          "allowance_seeds"=>2,
-          "argentina_invoicing_detail_seeds"=>1,
-          "domicile_seeds"=>1,
-          "email_seeds"=>1,
-          "identification_seeds"=>1,
-          "natural_docket_seeds"=>1,
-          "note_seeds"=>1,
-          "affinities"=>1,
-          "allowances"=>2,
-          "argentina_invoicing_details"=>1,
-          "domiciles"=>1,
-          "emails"=>1,
-          "fund_deposits"=>1,
-          "identifications"=>1,
-          "natural_dockets"=>1,
-          "notes"=>1,
-          "phones"=>1,
-          "risk_scores"=>1,
-          "phone_seeds"=>1,
-          "risk_score_seeds"=>1
+          "attachments"=>66, 
+          "email_seeds"=>2, 
+          "emails"=>2, 
+          "identification_seeds"=>2, 
+          "identifications"=>2, 
+          "natural_docket_seeds"=>2, 
+          "natural_dockets"=>2, 
+          "people"=>3
         }
     end
   end

--- a/spec/requests/api/issues_spec.rb
+++ b/spec/requests/api/issues_spec.rb
@@ -9,7 +9,8 @@ describe Issue do
     :full_approved_natural_person_issue,
     {state_eq: 'approved'},
     'domicile_seeds,person',
-    'identification_seeds,domicile_seeds'
+    'identification_seeds,domicile_seeds',
+    -> { {} }, [3, 4, 2], 4, 4
 
   describe 'When fetching issues' do
     it 'includes relationships for all issues' do

--- a/spec/requests/api/system_spec.rb
+++ b/spec/requests/api/system_spec.rb
@@ -8,7 +8,7 @@ describe System do
 
     AdminUser.count.should == 1
     Person.count.should == 5
-    Issue.count.should == 2
+    Issue.count.should == 5
 
     post "/api/system/truncate",
       headers: { 'Authorization': "Token token=#{admin_user.api_token}" }
@@ -27,14 +27,14 @@ describe System do
 
     AdminUser.count.should == 1
     Person.count.should == 5
-    Issue.count.should == 2
+    Issue.count.should == 5
 
     post "/api/system/truncate",
       headers: { 'Authorization': "Token token=#{admin_user.api_token}" }
 
     AdminUser.count.should == 1
     Person.count.should == 5
-    Issue.count.should == 2
+    Issue.count.should == 5
 
     Rails.unstub(:env)
   end


### PR DESCRIPTION
Fixes https://github.com/bitex-la/compliance/issues/113

**Before**
![before](https://user-images.githubusercontent.com/3068138/49155444-b909b600-f2f9-11e8-8b0d-1122b228a1fc.gif)

**After**
Now autocomplete searches by people ID, email, names, phones and identification numbers
![after](https://user-images.githubusercontent.com/3068138/49155637-3cc3a280-f2fa-11e8-8784-0f7183b84a31.gif)


