### PR TITLE
Truncate all texts in extra info panel

### DIFF
--- a/app/admin/arbre_helpers.rb
+++ b/app/admin/arbre_helpers.rb
@@ -453,9 +453,9 @@ module ArbreHelpers
   def self.render_text_or_link(context, key, text)
     context.concat("<strong>#{key}: </strong>".html_safe) if key
     if text.starts_with?('http') || text.starts_with?('ftp') || text.starts_with?('https')
-      context.concat("<a href='#{text}' target='_blank'>#{ArbreHelpers.strip_html_tags(text).truncate(40, omission:'...')}</a><br/>".html_safe) 
+      context.concat("<a href='#{text}' target='_blank'>#{ArbreHelpers.strip_and_truncate(text)}</a><br/>".html_safe) 
     else
-      context.concat("#{ArbreHelpers.strip_html_tags(text)}<br/>".html_safe) 
+      context.concat("#{ArbreHelpers.strip_and_truncate(text)}<br/>".html_safe) 
     end
   end
 
@@ -464,13 +464,17 @@ module ArbreHelpers
       strong "#{key}: "
       if text.starts_with?('http') || text.starts_with?('ftp') || text.starts_with?('https')
         span do
-          link_to ArbreHelpers.strip_html_tags(text).truncate(40, omission:'...'), text, target: "_blank"
+          link_to ArbreHelpers.strip_and_truncate(text), text, target: "_blank"
         end
       else
-        span ArbreHelpers.strip_html_tags(text)
+        span ArbreHelpers.strip_and_truncate(text)
       end
       br
     end
+  end
+
+  def self.strip_and_truncate(length = 40, text)
+    ArbreHelpers.strip_html_tags(text).truncate(length, omission:'...')
   end
 
   def self.strip_html_tags(text)

--- a/spec/features/compliance_spec.rb
+++ b/spec/features/compliance_spec.rb
@@ -84,7 +84,7 @@ describe 'an admin user' do
     within '.extra_info' do
       expect(page)
         .to have_content "link: #{"https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n".truncate(40, omission:'...')}"
-      expect(page).to have_content 'title: de 18 mil familias de clase media - PDF - DocPlayer'
+      expect(page).to have_content 'title: de 18 mil familias de clase media - P...'
     end
 
     assert_logging(issue, :update_entity, 2)
@@ -117,7 +117,7 @@ describe 'an admin user' do
 
     within '.extra_info' do
       expect(page).to have_content "link: #{"https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n".truncate(40, omission:'...')}"
-      expect(page).to have_content 'title: de 18 mil familias de clase media - PDF - DocPlayer'
+      expect(page).to have_content 'title: de 18 mil familias de clase media - P...'
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/bitex-la/storyboard/issues/207

**Before**
![extra-info-before](https://user-images.githubusercontent.com/3068138/54756474-15edec80-4bc7-11e9-9421-cedafa531841.gif)

**After**
![extra-info-after](https://user-images.githubusercontent.com/3068138/54756494-1edebe00-4bc7-11e9-9437-e345504d93be.gif)
