### PR TITLE
Update machine executor image to Ubuntu 16.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
 jobs:
   build:
+    machine: ubuntu-1604:201903-01
     working_directory: ~/home/compliance
     parallelism: 4
     environment:
@@ -47,6 +48,10 @@ jobs:
       - run: bundle exec rails db:create db:schema:load db:migrate
       - run: mkdir -p $CIRCLE_TEST_REPORTS/rspec
       - run: bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/rspec.xml --format progress $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split)
+      - run:
+          name: Install deps for heic/heif support
+          command: |
+            sudo add-apt-repository ppa:strukturag/libheif -y && sudo apt-get -qq update && sudo apt-get -qq install libheif-examples
       - store_test_results:
           path: /tmp/circleci-test-results
       - store_artifacts:


### PR DESCRIPTION
This allows updating the circleci machine executor, so compliance can
support heif/heic images.

fixes: https://github.com/bitex-la/storyboard/issues/683