### PR TITLE
Validate types and scope presence

### DIFF
--- a/app/admin/issues.rb
+++ b/app/admin/issues.rb
@@ -213,31 +213,31 @@ ActiveAdmin.register Issue do
         end
       end
 
-      ArbreHelpers::Layout.tab_with_counter_for(self, 'Workflows', resource.workflows.count, 'arrows-alt') do
-        ArbreHelpers::Form.has_many_form self, f, :workflows do |wf, context|
-          wf.template.concat(
-            Arbre::Context.new({}, wf.template){
-              li do
-                ArbreHelpers::Workflow.render_workflow_progress(self, "workflow", wf.object)
-              end
-            }.to_s
-          )
-          wf.input :scope
-          wf.input :workflow_type
-          if !wf.object.new_record?
-            wf.input :state, input_html: { disabled: wf.object.persisted? } 
-            if wf.object.may_finish? || wf.object.may_start?
-              wf.template.concat(
-                Arbre::Context.new({}, wf.template){
-                  li do
-                    link_to 'Mark as finished', [:finish, wf.object], class: 'button', method: :post
-                  end
-              }.to_s)
-            end
-          end  
-          ArbreHelpers::Task.has_many_tasks(context, wf)
-        end
-      end
+      # ArbreHelpers::Layout.tab_with_counter_for(self, 'Workflows', resource.workflows.count, 'arrows-alt') do
+      #   ArbreHelpers::Form.has_many_form self, f, :workflows do |wf, context|
+      #     wf.template.concat(
+      #       Arbre::Context.new({}, wf.template){
+      #         li do
+      #           ArbreHelpers::Workflow.render_workflow_progress(self, "workflow", wf.object)
+      #         end
+      #       }.to_s
+      #     )
+      #     wf.input :scope
+      #     wf.input :workflow_type
+      #     if !wf.object.new_record?
+      #       wf.input :state, input_html: { disabled: wf.object.persisted? } 
+      #       if wf.object.may_finish? || wf.object.may_start?
+      #         wf.template.concat(
+      #           Arbre::Context.new({}, wf.template){
+      #             li do
+      #               link_to 'Mark as finished', [:finish, wf.object], class: 'button', method: :post
+      #             end
+      #         }.to_s)
+      #       end
+      #     end  
+      #     ArbreHelpers::Task.has_many_tasks(context, wf)
+      #   end
+      # end
       
       if resource.for_person_type == :legal_entity || resource.for_person_type.nil?
         ArbreHelpers::Seed.seed_collection_and_fruits_edit_tab(self, 'industry', LegalEntityDocketSeed) do

--- a/app/admin/issues.rb
+++ b/app/admin/issues.rb
@@ -213,6 +213,7 @@ ActiveAdmin.register Issue do
         end
       end
 
+      # TODO: Uncomment when workflow implementation are ready for production
       # ArbreHelpers::Layout.tab_with_counter_for(self, 'Workflows', resource.workflows.count, 'arrows-alt') do
       #   ArbreHelpers::Form.has_many_form self, f, :workflows do |wf, context|
       #     wf.template.concat(

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,12 +1,14 @@
 class Task < ApplicationRecord
   include AASM
   include Loggable
-  
+
   belongs_to :workflow
 
   ransack_alias :state, :aasm_state
 
-  aasm do 
+  validates :task_type, presence: true
+
+  aasm do
     state :new, initial: true
     state :started
     state :performed
@@ -17,7 +19,7 @@ class Task < ApplicationRecord
       transitions from: [:new, :started], to: :started, guard: :start_workflow!
     end
 
-    event :finish do 
+    event :finish do
       transitions from: [:started, :retried, :performed], to: :performed, guard: :has_an_output?
     end
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -20,6 +20,9 @@ class Workflow < ApplicationRecord
     tasks.destroy_all
   end
 
+  validates :workflow_type, presence: true
+  validates :scope, inclusion: { in: scopes }
+
   scope :running, -> {
     joins(:issue)
     .where(aasm_state: 'started')
@@ -62,31 +65,32 @@ class Workflow < ApplicationRecord
   end
 
   def name
-   "Workflow ##{id} - #{workflow_type}"
+    "Workflow ##{id} - #{workflow_type}"
   end
 
   def state
     aasm_state
   end
-  
+
   def all_task_in_final_state?
-    tasks.all? {|task| task.performed? || task.failed?}
+    tasks.all? { |task| task.performed? || task.failed? }
   end
 
   def all_tasks_performed?
-    tasks.all? {|task| task.performed?}
+    tasks.all?(&:performed?)
   end
-  
+
   def any_task_failed?
-    tasks.any? {|task| task.failed? && !task.can_retry?}
+    tasks.any? { |task| task.failed? && !task.can_retry? }
   end
 
   def completed_tasks
-    tasks.select{|x| x.performed?}
+    tasks.select(&:performed?)
   end
 
   def completness_ratio
     return 0 if tasks.empty?
+
     (completed_tasks.count.fdiv(tasks.count) * 100).round
   end
 end

--- a/spec/features/compliance_spec.rb
+++ b/spec/features/compliance_spec.rb
@@ -164,153 +164,153 @@ describe 'an admin user' do
     end
   end
 
-  it 'creates a new natural person and its issue via admin with workflows' do
-    AdminUser.current_admin_user = admin_user
-    observation_reason = create(:human_world_check_reason)
+  # it 'creates a new natural person and its issue via admin with workflows' do
+  #   AdminUser.current_admin_user = admin_user
+  #   observation_reason = create(:human_world_check_reason)
    
-    login_as admin_user
+  #   login_as admin_user
 
-    click_link 'People'
-    click_link 'New Person'
-    click_button 'Create Person'
+  #   click_link 'People'
+  #   click_link 'New Person'
+  #   click_button 'Create Person'
 
-    Person.count.should == 1
+  #   Person.count.should == 1
 
-    visit '/'
-    click_link 'People'
-    click_link 'All'
-    within "tr[id='person_#{Person.first.id}'] td[class='col col-actions']" do
-      click_link 'View'
-    end
+  #   visit '/'
+  #   click_link 'People'
+  #   click_link 'All'
+  #   within "tr[id='person_#{Person.first.id}'] td[class='col col-actions']" do
+  #     click_link 'View'
+  #   end
 
-    click_link 'Add Person Information'
-    click_button 'Create new issue'
+  #   click_link 'Add Person Information'
+  #   click_button 'Create new issue'
     
-    fulfil_new_issue_form true
+  #   fulfil_new_issue_form true
 
-    click_button "Update Issue"
-    click_link "Edit"
+  #   click_button "Update Issue"
+  #   click_link "Edit"
 
-    issue = Issue.last
-    assert_logging(issue, :create_entity, 1)
+  #   issue = Issue.last
+  #   assert_logging(issue, :create_entity, 1)
 
-    # Fake here that an implementor set workflow tasks
-    task_one = create(:basic_task, workflow: issue.workflows.first)
-    task_two = create(:basic_task, workflow: issue.workflows.first)
+  #   # Fake here that an implementor set workflow tasks
+  #   task_one = create(:basic_task, workflow: issue.workflows.first)
+  #   task_two = create(:basic_task, workflow: issue.workflows.first)
 
-    %i(identification_seeds domicile_seeds allowance_seeds).each do |seed|
-      issue.send(seed).count.should == 1
-      issue.send(seed).first.attachments.count == 1
-    end
+  #   %i(identification_seeds domicile_seeds allowance_seeds).each do |seed|
+  #     issue.send(seed).count.should == 1
+  #     issue.send(seed).first.attachments.count == 1
+  #   end
 
-    issue.identification_seeds.first.attachments
-      .first.document_file_name.should == 'an_simple_????.jpg'
+  #   issue.identification_seeds.first.attachments
+  #     .first.document_file_name.should == 'an_simple_????.jpg'
 
-    issue.domicile_seeds.first.attachments
-      .first.document_file_name.should == 'an_simple_????.zip'
+  #   issue.domicile_seeds.first.attachments
+  #     .first.document_file_name.should == 'an_simple_????.zip'
 
-    issue.allowance_seeds.first.attachments
-      .first.document_file_name.should == 'an_simple_????.gif'
+  #   issue.allowance_seeds.first.attachments
+  #     .first.document_file_name.should == 'an_simple_????.gif'
 
-    issue.natural_docket_seed.should == NaturalDocketSeed.last
-    issue.should be_draft
+  #   issue.natural_docket_seed.should == NaturalDocketSeed.last
+  #   issue.should be_draft
     
-    find('li[title="Risk scores"] a').click
+  #   find('li[title="Risk scores"] a').click
 
-    within '.external_links' do
-      expect(page).to have_content 'Link #1'
-      expect(page).to have_content 'Link #2'
-    end
+  #   within '.external_links' do
+  #     expect(page).to have_content 'Link #1'
+  #     expect(page).to have_content 'Link #2'
+  #   end
 
-    within '.extra_info' do
-      expect(page)
-        .to have_content "link: #{"https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n".truncate(40, omission:'...')}"
-      expect(page).to have_content 'title: de 18 mil familias de clase media - P...'
-    end
+  #   within '.extra_info' do
+  #     expect(page)
+  #       .to have_content "link: #{"https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n".truncate(40, omission:'...')}"
+  #     expect(page).to have_content 'title: de 18 mil familias de clase media - P...'
+  #   end
 
-    assert_logging(issue, :update_entity, 5)
-    issue.reload.should be_draft
+  #   assert_logging(issue, :update_entity, 5)
+  #   issue.reload.should be_draft
 
-    expect(page).to_not have_content("Approve")
+  #   expect(page).to_not have_content("Approve")
 
-    task_one.start!
-    task_one.update!(output: 'All ok')
-    task_one.finish!
+  #   task_one.start!
+  #   task_one.update!(output: 'All ok')
+  #   task_one.finish!
 
-    click_button "Update Issue"
-    click_link "Edit"
+  #   click_button "Update Issue"
+  #   click_link "Edit"
 
-    find('li[title="Workflows"] a').click
-    expect(page).to have_content("workflow completed at 50%")
+  #   find('li[title="Workflows"] a').click
+  #   expect(page).to have_content("workflow completed at 50%")
     
-    task_two.start!
-    task_two.update!(output: 'All ok')
-    task_two.finish!
+  #   task_two.start!
+  #   task_two.update!(output: 'All ok')
+  #   task_two.finish!
 
-    issue.complete!
+  #   issue.complete!
 
-    #fake here that issue goes to answered
-    issue.workflows.first.finish!
+  #   #fake here that issue goes to answered
+  #   issue.workflows.first.finish!
 
-    expect(issue.reload.state).to eq 'new'
+  #   expect(issue.reload.state).to eq 'new'
 
-    click_button "Update Issue"
-    click_link "Edit"
+  #   click_button "Update Issue"
+  #   click_link "Edit"
 
-    find('li[title="Workflows"] a').click
-    expect(page).to have_content("workflow completed at 100%")
+  #   find('li[title="Workflows"] a').click
+  #   expect(page).to have_content("workflow completed at 100%")
 
-    click_link "Cancel"
+  #   click_link "Cancel"
 
-    expect(page).to have_content("Approve")
-    click_link "Approve"
+  #   expect(page).to have_content("Approve")
+  #   click_link "Approve"
     
-    visit "/people/#{issue.person.id}"
+  #   visit "/people/#{issue.person.id}"
     
-    issue.reload.should be_approved
-    assert_logging(issue, :update_entity, 17)
-    expect(issue.person.enabled).to be_falsey
-    expect(issue.person.state).to eq('new')
-    assert_logging(issue.person, :enable_person, 0)
+  #   issue.reload.should be_approved
+  #   assert_logging(issue, :update_entity, 17)
+  #   expect(issue.person.enabled).to be_falsey
+  #   expect(issue.person.state).to eq('new')
+  #   assert_logging(issue.person, :enable_person, 0)
 
-    find('li[title="Risk scores"] a').click
+  #   find('li[title="Risk scores"] a').click
 
-    within '.external_links' do
-      expect(page).to have_content 'Link #1'
-      expect(page).to have_content 'Link #2'
-    end
+  #   within '.external_links' do
+  #     expect(page).to have_content 'Link #1'
+  #     expect(page).to have_content 'Link #2'
+  #   end
 
-    within '.extra_info' do
-      expect(page).to have_content "link: #{"https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n".truncate(40, omission:'...')}"
-      expect(page).to have_content 'title: de 18 mil familias de clase media - P...'
-    end
+  #   within '.extra_info' do
+  #     expect(page).to have_content "link: #{"https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n".truncate(40, omission:'...')}"
+  #     expect(page).to have_content 'title: de 18 mil familias de clase media - P...'
+  #   end
 
-    click_link 'Enable'
+  #   click_link 'Enable'
 
-    expect(issue.person.reload.enabled).to be_truthy
-    expect(issue.person.state).to eq('enabled')
-    assert_logging(issue.person, :enable_person, 1)
+  #   expect(issue.person.reload.enabled).to be_truthy
+  #   expect(issue.person.state).to eq('enabled')
+  #   assert_logging(issue.person, :enable_person, 1)
     
-    click_link 'Edit Person'
-    click_link 'Disable'
-    assert_logging(issue.person, :enable_person, 1)
-    assert_logging(issue.person, :disable_person, 1)
-    expect(issue.person.reload.enabled).to be_falsey
-    expect(issue.person.state).to eq('disabled')
+  #   click_link 'Edit Person'
+  #   click_link 'Disable'
+  #   assert_logging(issue.person, :enable_person, 1)
+  #   assert_logging(issue.person, :disable_person, 1)
+  #   expect(issue.person.reload.enabled).to be_falsey
+  #   expect(issue.person.state).to eq('disabled')
 
-    click_link 'Edit Person'
-    click_link 'Enable'
+  #   click_link 'Edit Person'
+  #   click_link 'Enable'
 
-    expect(issue.person.reload.enabled).to be_truthy
-    expect(issue.person.state).to eq('enabled')
-    assert_logging(issue.person, :enable_person, 2)
+  #   expect(issue.person.reload.enabled).to be_truthy
+  #   expect(issue.person.state).to eq('enabled')
+  #   assert_logging(issue.person, :enable_person, 2)
 
-    visit "/allowances/#{issue.person.allowances.first.id}"
+  #   visit "/allowances/#{issue.person.allowances.first.id}"
     
-    within '#page_title' do
-      expect(page).to have_content 'Allowance#1'
-    end
-  end
+  #   within '#page_title' do
+  #     expect(page).to have_content 'Allowance#1'
+  #   end
+  # end
 
   it 'reviews a newly created customer' do
     person = create :new_natural_person

--- a/spec/features/compliance_spec.rb
+++ b/spec/features/compliance_spec.rb
@@ -164,6 +164,7 @@ describe 'an admin user' do
     end
   end
 
+  # TODO: Uncomment when workflow implementation are ready for production
   # it 'creates a new natural person and its issue via admin with workflows' do
   #   AdminUser.current_admin_user = admin_user
   #   observation_reason = create(:human_world_check_reason)

--- a/spec/features/restricted_admin_spec.rb
+++ b/spec/features/restricted_admin_spec.rb
@@ -91,6 +91,7 @@ describe 'a restricted admin user' do
     expect(page).to_not have_content 'Reject'
   end
 
+  # TODO: Uncomment when workflow implementation are ready for production
   # it 'can create a natural person and it issue, but cannot approve, reject, dismiss or abandon it with workflows' do
   #   observation_reason = create(:human_world_check_reason)
   #   login_as restricted_user

--- a/spec/features/restricted_admin_spec.rb
+++ b/spec/features/restricted_admin_spec.rb
@@ -91,51 +91,51 @@ describe 'a restricted admin user' do
     expect(page).to_not have_content 'Reject'
   end
 
-  it 'can create a natural person and it issue, but cannot approve, reject, dismiss or abandon it with workflows' do
-    observation_reason = create(:human_world_check_reason)
-    login_as restricted_user
+  # it 'can create a natural person and it issue, but cannot approve, reject, dismiss or abandon it with workflows' do
+  #   observation_reason = create(:human_world_check_reason)
+  #   login_as restricted_user
 
-    click_link 'People'
-    click_link 'New Person'
-    click_button 'Create Person'
+  #   click_link 'People'
+  #   click_link 'New Person'
+  #   click_button 'Create Person'
 
-    visit '/'
-    click_link 'People'
-    within "tr[id='person_#{Person.first.id}'] td[class='col col-actions']" do
-      click_link 'View'
-    end
+  #   visit '/'
+  #   click_link 'People'
+  #   within "tr[id='person_#{Person.first.id}'] td[class='col col-actions']" do
+  #     click_link 'View'
+  #   end
 
-    click_link 'Edit Person'
+  #   click_link 'Edit Person'
 
-    expect(page).to_not have_content 'Enable'
-    expect(page).to_not have_content 'Disable'
+  #   expect(page).to_not have_content 'Enable'
+  #   expect(page).to_not have_content 'Disable'
     
-    click_link 'View Person Issues'
-    click_link 'New'
+  #   click_link 'View Person Issues'
+  #   click_link 'New'
     
-    fulfil_new_issue_form true
+  #   fulfil_new_issue_form true
 
-    click_button "Create Issue"
-    click_link "Edit"
+  #   click_button "Create Issue"
+  #   click_link "Edit"
 
-    add_observation(observation_reason, 'Please check this guy on world check')
+  #   add_observation(observation_reason, 'Please check this guy on world check')
 
-    click_button "Update Issue"
-    click_link "Edit"
+  #   click_button "Update Issue"
+  #   click_link "Edit"
 
-    find('li[title="Workflows"] a').click
+  #   find('li[title="Workflows"] a').click
 
-    within '.has_many_container.workflows' do
-      click_link 'Mark as finished'
-    end
+  #   within '.has_many_container.workflows' do
+  #     click_link 'Mark as finished'
+  #   end
     
-    expect(page).to have_content 'You are not authorized to perform this action'
+  #   expect(page).to have_content 'You are not authorized to perform this action'
 
-    expect(page).to_not have_content 'Approve'
-    expect(page).to_not have_content 'Dismiss'
-    expect(page).to_not have_content 'Abandon'
-    expect(page).to_not have_content 'Reject'
-  end
+  #   expect(page).to_not have_content 'Approve'
+  #   expect(page).to_not have_content 'Dismiss'
+  #   expect(page).to_not have_content 'Abandon'
+  #   expect(page).to_not have_content 'Reject'
+  # end
 
   it 'can edit an issue' do
     person = create(:full_natural_person).reload

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe Task, type: :model do
 
   it 'is not valid without a workflow' do
     expect(invalid_task).to_not be_valid
+    expect(invalid_task.errors[:workflow]).to eq ["must exist"]
+    expect(invalid_task.errors[:task_type]).to eq ["can't be blank"]
   end
 
-  it 'is valid with a workflow' do
+  it 'is valid with a workflow and type' do
     expect(basic_task).to be_valid
   end
 

--- a/spec/requests/api/workflows_spec.rb
+++ b/spec/requests/api/workflows_spec.rb
@@ -35,7 +35,8 @@ describe Workflow do
         api_create('/workflows', {
           type: 'workflows',
           attributes: {
-            workflow_kind_code: 'onboarding'
+            workflow_type: 'onboarding',
+            scope: 'robot'
           },
           relationships: {
             issue: {data:{id: issue.id, type: 'issues'}}
@@ -48,8 +49,10 @@ describe Workflow do
 
       api_get("/workflows/#{workflow.id}")
 
-      api_response.data.relationships.issue
-        .data.id.to_i.should == issue.id 
+      data = api_response.data
+      expect(data.relationships.issue.data.id.to_i).to eq issue.id
+      expect(data.attributes.scope).to eq "robot"
+      expect(data.attributes.workflow_type).to eq "onboarding"
 
       api_response.included.select{|o| o.type == 'issues'}
         .map(&:id).should == [issue.id.to_s]


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/773

Por ahora solo se valida que tenga scope y un type distinto de nil y se quito termporalmente la posibilidad de crear workflows desde el admin hasta que este la funcionalidad completa.

Mas adelante deberiamos crear una lista de types validos par workflows y tasks.


Para evitar que el bug reportado en https://github.com/bitex-la/storyboard/issues/768 vuelva a ocurrir se esta armando otro PR para que no se ejecuten workflows invalidos
