### PR TITLE
Backport request limit cryptocambios implementation

### DIFF
--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -61,7 +61,10 @@ ActiveAdmin.register AdminUser do
     column :sign_in_count
     column :max_people_allowed
     column(:person_view_count) do |o|
-      o.request_limit_counter.value
+      o.request_limit_set.length
+    end
+    column(:rejected_person_view_count) do |o|
+      o.request_limit_rejected_set.length
     end
     column :created_at
     actions

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_current_user
-  before_action :verify_request, except: [:index, :create]
+  before_action :verify_request, except: [:index, :create, :new, :batch_action]
 
   private
 
@@ -16,27 +16,53 @@ class ApplicationController < ActionController::Base
   end
 
   def verify_request
-    current_user = AdminUser.current_admin_user
-    return if current_user.nil?
+    current_admin_user = AdminUser.current_admin_user
+    return if current_admin_user.nil?
 
     person_id = related_person.to_s
     return if person_id.empty?
 
-    set = current_user.request_limit_set
-    return if set.member? person_id
+    set = current_admin_user.request_limit_set
+    limit = current_admin_user.max_people_allowed
 
-    counter = current_user.request_limit_counter
-    new_value = counter.increment
+    if limit.nil?
+      # si no hay limite configurado o existia y se modifico, no borro 
+      # los usuarios rechazados para que puedan consultarse en el admin 
+      # hasta que expiren. solo incremento el score de los usuarios permitidos.
+      set.increment person_id
+    else
+      counter = current_admin_user.request_limit_counter
+      rejected_set = current_admin_user.request_limit_rejected_set
 
-    limit = current_user.max_people_allowed
-
-    unless limit.nil?
-      return render body: nil, status: 400 if new_value > limit
+      # si existe limite y el usuario ya esta incluido en el set de permitidos
+      # incremento el score.
+      if set.member? person_id
+        set.increment person_id
+      else
+        # si no esta en el set valido si puedo agregarlo aumentando el contador atomicamente
+        if counter.increment <= limit
+          # si el valor incrementado es menor o igual al limite
+          # incremento el score en el set de permitidos
+          # si el usuario ya existia en el set decremento el contador para
+          # dejar lugar a un futuro usuario.
+          # el increment evita una condicion de carrera entre 2 request del mismo user_id
+          unless set.increment(person_id) == 1
+            counter.decrement
+          end
+          # elimino el usuario del set de rechazados si existe
+          rejected_set.delete person_id
+        else
+          # si se supera el limite, decremento el contador para permitir
+          # modificaciones dinamicas del limite e incremento el score en el set
+          # de usuarios rechazados y retorno error 400.
+          counter.decrement
+          rejected_set.increment person_id
+          render body: nil, status: 400
+        end
+      end
     end
-
-    set << person_id
   end
-
+  
   def related_person
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -28,7 +28,14 @@ class AdminUser < ApplicationRecord
     now = Time.now
     now_string = now.strftime('%Y%m%d')
     expire_at = (now + 1.week).end_of_day
-    Redis::Set.new("request_limit:people:#{id}:#{now_string}", :expireat => expire_at)
+    Redis::SortedSet.new("request_limit:people:#{id}:#{now_string}", :expireat => expire_at)
+  end
+
+  def request_limit_rejected_set
+    now = Time.now
+    now_string = now.strftime('%Y%m%d')
+    expire_at = (now + 1.week).end_of_day
+    Redis::SortedSet.new("request_limit:rejected_people:#{id}:#{now_string}", :expireat => expire_at)
   end
 
   def request_limit_counter


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/730


Es necesario limpiar las keys de redis luego del deploy.

por ej con 

Redis::Objects.redis.flushdb o limitar el borrado a las keys de request limit.
@nubis @tmsrjs 


