### PR TITLE
Fix defer_until

### DIFF
--- a/app/admin/issues.rb
+++ b/app/admin/issues.rb
@@ -480,7 +480,7 @@ ActiveAdmin.register Issue do
           h3 "Current Note Seeds"
           if seeds = resource.note_seeds.presence
             ArbreHelpers::Layout.panel_grid(self, seeds) do |d|
-              attributes_table_for d, :public,  :fruit, :created_at, :updated_at
+              attributes_table_for d, :public,  :fruit, :created_at, :updated_at, :expires_at
               para d.body
               ArbreHelpers::Attachment.attachments_list self, (d.fruit.try(:attachments) || d.attachments)
             end

--- a/lib/garden.rb
+++ b/lib/garden.rb
@@ -138,12 +138,11 @@ module Garden
     end
 
     def create_deferred_issue(fruit)
-      new_issue = issue.person.issues.create(defer_until: expires_at, state: 'new')
+      defer_until = expires_at < Date.today ? nil : expires_at
+      new_issue = issue.person.issues.create(defer_until: defer_until, state: 'new')
       new_issue.add_seeds_replacing([fruit])
       new_issue.save!
     end
-
-    
   end
 
   module Fruit

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -79,6 +79,20 @@ RSpec.describe Issue, type: :model do
     expect(empty_issue.errors.messages.keys.first).to eq(:"note_seeds.expires_at")
   end
 
+  it 'create deferred issue with valid defer_until if seed expire_at is in the past' do
+    empty_issue.note_seeds.create(title:'title', body: 'body', expires_at: 1.month.from_now)
+    empty_issue.save
+    empty_issue.reload
+
+    Timecop.travel 3.months.from_now
+
+    expect do
+      empty_issue.approve!
+    end.to change { Issue.count }.by(1)
+
+    expect(Issue.last.defer_until).to eq Date.today
+  end
+
   describe 'when transitioning' do
     it 'defaults to draft' do
       expect(empty_issue).to have_state(:draft)


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/802#event-3013508004

Cuando un seed tenia una expire_at inferior a la fecha actual, la issue generada quedaba en un estado invalido y daba error algo guardarse.

Ahora si la fecha es inferior a la fecha del dia, se setea en nil, internamente al guardar la issue se setea el defer_until con la fecha del dia.
