### PR TITLE
Add contraints to fund_deposits

### DIFF
--- a/app/models/fund_deposit.rb
+++ b/app/models/fund_deposit.rb
@@ -2,7 +2,7 @@ class FundDeposit < ApplicationRecord
   include Loggable
 
   validates :country, country: true
-  validates :deposit_date, presence: true, on: :create
+  validates :deposit_date, presence: true
   validates :external_id, presence: true
   validates :deposit_method, inclusion: { in: DepositMethod.all }
   validates :currency, inclusion: { in: Currency.all }

--- a/db/migrate/20200611160057_add_contraints_to_fund_deposits.rb
+++ b/db/migrate/20200611160057_add_contraints_to_fund_deposits.rb
@@ -1,0 +1,7 @@
+class AddContraintsToFundDeposits < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :fund_deposits, :deposit_date, false
+    change_column_null :fund_deposits, :country, false
+    change_column_null :fund_deposits, :external_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -363,10 +363,10 @@ ActiveRecord::Schema.define(version: 2020_04_09_160444) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "replaced_by_id"
-    t.string "external_id"
+    t.string "external_id", null: false
     t.decimal "exchange_rate_adjusted_amount", precision: 20, scale: 8, null: false
-    t.datetime "deposit_date"
-    t.string "country"
+    t.datetime "deposit_date", null: false
+    t.string "country", null: false
     t.index ["person_id", "country"], name: "index_fund_deposits_on_person_id_and_country"
     t.index ["person_id"], name: "index_fund_deposits_on_person_id"
     t.index ["replaced_by_id"], name: "index_fund_deposits_on_replaced_by_id"

--- a/spec/models/fund_deposit_spec.rb
+++ b/spec/models/fund_deposit_spec.rb
@@ -31,18 +31,6 @@ RSpec.describe FundDeposit do
     expect(object.errors.messages.keys.first).to eq(:deposit_date)
   end
 
-  it 'is valid update a deposit without deposit_date' do
-    old_fund_deposit = build(:fund_deposit, deposit_date: nil, person: create(:empty_person))
-    old_fund_deposit.save(validate: false)
-    old_fund_deposit.update!(amount: 303.00)
-
-    expect(old_fund_deposit).to be_valid
-
-    old_fund_deposit.reload
-
-    expect(old_fund_deposit.amount).to eq(303.00)
-  end
-
   it 'logs creation of fund deposits' do
     object = create(:full_fund_deposit, person: person)
     assert_logging(object, :create_entity, 1)


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/916


Este PR solo se debe poner en produccion si no queda ningun registro en compliance con los datos en nil para los campos deposit_date, country o external_id. 

lo voy a correr en staging primero.
