### PR TITLE
Issue priority

### DIFF
--- a/app/admin/issues.rb
+++ b/app/admin/issues.rb
@@ -162,6 +162,7 @@ ActiveAdmin.register Issue do
           column do
             attributes_table_for resource do
               row :id
+              row :priority
               row :state
               row :person
               row :reason if f.object.persisted?

--- a/app/admin/issues_dashboard.rb
+++ b/app/admin/issues_dashboard.rb
@@ -36,7 +36,7 @@ ActiveAdmin.register Issue, sort_order: :priority_desc, as: "Dashboard" do
     'priority desc, id asc'
   end
 
-  index(title: '案 Issues Dashboard', row_class: -> record { record.priority.zero? ? 'even' : 'top-priority' }) do
+  index(title: '案 Issues Dashboard', row_class: -> record { record.priority.zero? ? 'zero-priority' : 'top-priority' }) do
     column(:priority)
     column(:id)  do |o|
       link_to o.id, [o.person, o]

--- a/app/admin/issues_dashboard.rb
+++ b/app/admin/issues_dashboard.rb
@@ -1,5 +1,5 @@
 #encoding: utf-8
-ActiveAdmin.register Issue, as: "Dashboard" do
+ActiveAdmin.register Issue, sort_order: :priority_desc, as: "Dashboard" do
   menu priority: 1
 
   actions :index
@@ -32,7 +32,12 @@ ActiveAdmin.register Issue, as: "Dashboard" do
   filter :created_at
   filter :updated_at
 
+  order_by(:priority) do
+    'priority desc, id asc'
+  end
+
   index title: '案 Issues Dashboard' do
+    column(:priority)
     column(:id)  do |o|
       link_to o.id, [o.person, o]
     end

--- a/app/admin/issues_dashboard.rb
+++ b/app/admin/issues_dashboard.rb
@@ -36,7 +36,7 @@ ActiveAdmin.register Issue, sort_order: :priority_desc, as: "Dashboard" do
     'priority desc, id asc'
   end
 
-  index title: '案 Issues Dashboard' do
+  index(title: '案 Issues Dashboard', row_class: -> record { record.priority.zero? ? 'even' : 'top-priority' }) do
     column(:priority)
     column(:id)  do |o|
       link_to o.id, [o.person, o]

--- a/app/admin/issues_dashboard.rb
+++ b/app/admin/issues_dashboard.rb
@@ -36,7 +36,7 @@ ActiveAdmin.register Issue, sort_order: :priority_desc, as: "Dashboard" do
     'priority desc, id desc'
   end
 
-  index(title: '案 Issues Dashboard', row_class: -> record { record.priority.zero? ? 'zero-priority' : 'top-priority' }) do
+  index(title: '案 Issues Dashboard', row_class: ->(record) { 'top-priority' unless record.priority.zero? }) do
     column(:priority)
     column(:id)  do |o|
       link_to o.id, [o.person, o]

--- a/app/admin/issues_dashboard.rb
+++ b/app/admin/issues_dashboard.rb
@@ -33,7 +33,7 @@ ActiveAdmin.register Issue, sort_order: :priority_desc, as: "Dashboard" do
   filter :updated_at
 
   order_by(:priority) do
-    'priority desc, id asc'
+    'priority desc, id desc'
   end
 
   index(title: '案 Issues Dashboard', row_class: -> record { record.priority.zero? ? 'zero-priority' : 'top-priority' }) do

--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -925,7 +925,3 @@ span.icon-text-fa {
 .top-priority {
   background-color: #ffeded;
 }
-
-.zero-priority {
-  background-color: #f3f3f3;
-}

--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -469,6 +469,12 @@ body.active_admin{
     tr.even td{
       background: #f9f9f9;
     }
+    tr.top-priority td{
+      background-color: #ffeded;
+    }
+    tr.zero-priority td{
+      background-color: #f0f0f0;
+    }
   }
   table.origins_and_destinations td.main{
     width: 30%;
@@ -920,8 +926,4 @@ span.icon-text-fa {
   li a {
     text-align: left !important;
   }
-}
-
-.top-priority {
-  background-color: #ffeded;
 }

--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -472,9 +472,6 @@ body.active_admin{
     tr.top-priority td{
       background-color: #ffeded;
     }
-    tr.zero-priority td{
-      background-color: #f0f0f0;
-    }
   }
   table.origins_and_destinations td.main{
     width: 30%;

--- a/app/assets/stylesheets/active_admin.css.scss
+++ b/app/assets/stylesheets/active_admin.css.scss
@@ -914,11 +914,18 @@ span.icon-text-fa {
   text-shadow: none;
 }
 
-
 .dropdown_other_actions {
   float: right;
   margin-bottom: 20px;
   li a {
     text-align: left !important;
   }
+}
+
+.top-priority {
+  background-color: #ffeded;
+}
+
+.zero-priority {
+  background-color: #f3f3f3;
 }

--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -43,7 +43,7 @@ class Api::IssuesController < Api::ApiController
   def update
     mapper = JsonapiMapper.doc_unsafe! params.permit!.to_h,
       [],
-      issues: [ :defer_until, id: params[:id] ]
+      issues: [:priority, :defer_until, id: params[:id]]
       
     return jsonapi_422 unless mapper.data
 

--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -26,7 +26,7 @@ class Api::IssuesController < Api::ApiController
   def create
     mapper = JsonapiMapper.doc_unsafe! params.permit!.to_h,
       [ :people , :tags],
-      issues: [:reason_code, :defer_until, :person, :tags, id: nil ],
+      issues: [:priority, :reason_code, :defer_until, :person, :tags, id: nil],
       people: [],
       tags: []
 

--- a/app/serializers/issue_serializer.rb
+++ b/app/serializers/issue_serializer.rb
@@ -13,5 +13,5 @@ class IssueSerializer
     :identification_seeds, :phone_seeds, :email_seeds, 
     :note_seeds, :affinity_seeds, :risk_score_seeds, :tags
   
-  attributes :state, :defer_until, :reason_code, :locked, :lock_expiration
+  attributes :priority, :state, :defer_until, :reason_code, :locked, :lock_expiration
 end

--- a/db/migrate/20200903204040_add_priority_to_issues.rb
+++ b/db/migrate/20200903204040_add_priority_to_issues.rb
@@ -1,0 +1,6 @@
+class AddPriorityToIssues < ActiveRecord::Migration[5.2]
+  def change
+    add_column :issues, :priority, :integer, null: false, default: 0
+    add_index :issues, [:priority, :id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_23_175323) do
+ActiveRecord::Schema.define(version: 2020_09_03_204040) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "namespace"
@@ -478,9 +478,11 @@ ActiveRecord::Schema.define(version: 2020_07_23_175323) do
     t.boolean "locked", default: false, null: false
     t.bigint "lock_admin_user_id"
     t.datetime "lock_expiration"
+    t.integer "priority", default: 0, null: false
     t.index ["aasm_state"], name: "index_issues_on_aasm_state"
     t.index ["lock_admin_user_id"], name: "index_issues_on_lock_admin_user_id"
     t.index ["person_id"], name: "index_issues_on_person_id"
+    t.index ["priority", "id"], name: "index_issues_on_priority_and_id"
   end
 
   create_table "legal_entity_docket_seeds", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -4,19 +4,19 @@ describe 'Dashboard' do
   it 'differentiates issues with priority bigger than zero' do
     login_as create(:admin_user)
 
-    2.times do
-      create(:basic_issue)
+    3.times do |n|
+      create(:basic_issue, priority: n + 1)
     end
 
-    4.times do |n|
-      create(:basic_issue, priority: n + 1)
+    4.times do
+      create(:basic_issue)
     end
 
     visit '/'
     click_link 'All'
 
-    expect(page).to have_selector(:css, '.top-priority', count: 4)
-    expect(page).to have_selector(:css, '.zero-priority', count: 2)
+    expect(page).to have_selector(:css, '.top-priority', count: 3)
+    expect(page).to have_selector(:css, '.zero-priority', count: 4)
 
     id1 = page.body.index('id="issue_1"')
     id2 = page.body.index('id="issue_2"')
@@ -24,11 +24,13 @@ describe 'Dashboard' do
     id4 = page.body.index('id="issue_4"')
     id5 = page.body.index('id="issue_5"')
     id6 = page.body.index('id="issue_6"')
+    id7 = page.body.index('id="issue_7"')
 
-    expect(id6).to be < id5
-    expect(id5).to be < id4
-    expect(id4).to be < id3
-    expect(id3).to be < id1
-    expect(id1).to be < id2
+    expect(id3).to be < id2
+    expect(id2).to be < id1
+    expect(id1).to be < id4
+    expect(id4).to be < id5
+    expect(id5).to be < id6
+    expect(id6).to be < id7
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -16,7 +16,6 @@ describe 'Dashboard' do
     click_link 'All'
 
     expect(page).to have_selector(:css, '.top-priority', count: 3)
-    expect(page).to have_selector(:css, '.zero-priority', count: 4)
 
     indexes = Array.new(7) do |i|
       page.body.index("id=\"issue_#{i + 1}\"")

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-describe 'Dashboard', js: true do
-  it 'differenciates rows with priority bigger than zero' do
+describe 'Dashboard' do
+  it 'differentiates issues with priority bigger than zero' do
     login_as create(:admin_user)
 
     5.times do |n|

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -18,19 +18,16 @@ describe 'Dashboard' do
     expect(page).to have_selector(:css, '.top-priority', count: 3)
     expect(page).to have_selector(:css, '.zero-priority', count: 4)
 
-    id1 = page.body.index('id="issue_1"')
-    id2 = page.body.index('id="issue_2"')
-    id3 = page.body.index('id="issue_3"')
-    id4 = page.body.index('id="issue_4"')
-    id5 = page.body.index('id="issue_5"')
-    id6 = page.body.index('id="issue_6"')
-    id7 = page.body.index('id="issue_7"')
+    indexes = Array.new(7) do |i|
+      page.body.index("id=\"issue_#{i + 1}\"")
+    end
 
-    expect(id3).to be < id2
-    expect(id2).to be < id1
-    expect(id1).to be < id4
-    expect(id4).to be < id5
-    expect(id5).to be < id6
-    expect(id6).to be < id7
+    expect(indexes.sort).to eq([indexes[2],
+      indexes[1],
+      indexes[0],
+      indexes[6],
+      indexes[5],
+      indexes[4],
+      indexes[3]])
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -5,7 +5,7 @@ describe 'Dashboard' do
     login_as create(:admin_user)
 
     5.times do |n|
-      create(:basic_issue, priority: n + 1)
+      create(:basic_issue, priority: n + 3)
     end
 
     6.times do
@@ -16,5 +16,6 @@ describe 'Dashboard' do
     click_link 'All'
     expect(page).to have_selector(:css, '.top-priority', count: 5)
     expect(page).to have_selector(:css, '.zero-priority', count: 6)
+    expect(page.text).to match(/7.+\n6.+\n5.+\n4.+\n3.+\n0.+\n0.+\n0.+\n0.+\n0.+\n0.+/)
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -1,21 +1,31 @@
 require 'rails_helper'
 
 describe 'Dashboard' do
+  def create_issue(first_name, last_name, priority)
+    issue=create(:basic_issue, priority: priority, person: create(:empty_person))
+    create(:natural_docket, first_name: first_name, last_name: last_name, person: issue.person)
+    issue.approve!
+  end
+
   it 'differentiates issues with priority bigger than zero' do
     login_as create(:admin_user)
 
-    5.times do |n|
-      create(:basic_issue, priority: n + 3)
-    end
-
-    6.times do
-      create(:basic_issue)
-    end
+    create_issue('Pedro', 'Perez', 0)
+    create_issue('María', 'Mendez', 1)
+    create_issue('Ricardo', 'Tapia', 0)
+    create_issue('Bruno', 'Diaz', 2)
+    create_issue('Miguel', 'Rodriguez', 1)
+    create_issue('Andrés', 'Andrada', 3)
 
     visit '/'
     click_link 'All'
-    expect(page).to have_selector(:css, '.top-priority', count: 5)
-    expect(page).to have_selector(:css, '.zero-priority', count: 6)
-    expect(page.text).to match(/7.+\n6.+\n5.+\n4.+\n3.+\n0.+\n0.+\n0.+\n0.+\n0.+\n0.+/)
+    expect(page).to have_selector(:css, '.top-priority', count: 4)
+    expect(page).to have_selector(:css, '.zero-priority', count: 2)
+
+    expect(page.text.index('Andrés Andrada')).to be < page.text.index('Bruno Diaz')
+    expect(page.text.index('Bruno Diaz')).to be < page.text.index('María Mendez')
+    expect(page.text.index('María Mendez')).to be < page.text.index('Miguel Rodriguez')
+    expect(page.text.index('Miguel Rodriguez')).to be < page.text.index('Pedro Perez')
+    expect(page.text.index('Pedro Perez')).to be < page.text.index('Ricardo Tapia')
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -1,31 +1,34 @@
 require 'rails_helper'
 
 describe 'Dashboard' do
-  def create_issue(first_name, last_name, priority)
-    issue=create(:basic_issue, priority: priority, person: create(:empty_person))
-    create(:natural_docket, first_name: first_name, last_name: last_name, person: issue.person)
-    issue.approve!
-  end
-
   it 'differentiates issues with priority bigger than zero' do
     login_as create(:admin_user)
 
-    create_issue('Pedro', 'Perez', 0)
-    create_issue('María', 'Mendez', 1)
-    create_issue('Ricardo', 'Tapia', 0)
-    create_issue('Bruno', 'Diaz', 2)
-    create_issue('Miguel', 'Rodriguez', 1)
-    create_issue('Andrés', 'Andrada', 3)
+    2.times do
+      create(:basic_issue)
+    end
+
+    4.times do |n|
+      create(:basic_issue, priority: n + 1)
+    end
 
     visit '/'
     click_link 'All'
+
     expect(page).to have_selector(:css, '.top-priority', count: 4)
     expect(page).to have_selector(:css, '.zero-priority', count: 2)
 
-    expect(page.text.index('Andrés Andrada')).to be < page.text.index('Bruno Diaz')
-    expect(page.text.index('Bruno Diaz')).to be < page.text.index('María Mendez')
-    expect(page.text.index('María Mendez')).to be < page.text.index('Miguel Rodriguez')
-    expect(page.text.index('Miguel Rodriguez')).to be < page.text.index('Pedro Perez')
-    expect(page.text.index('Pedro Perez')).to be < page.text.index('Ricardo Tapia')
+    id1 = page.body.index('id="issue_1"')
+    id2 = page.body.index('id="issue_2"')
+    id3 = page.body.index('id="issue_3"')
+    id4 = page.body.index('id="issue_4"')
+    id5 = page.body.index('id="issue_5"')
+    id6 = page.body.index('id="issue_6"')
+
+    expect(id6).to be < id5
+    expect(id5).to be < id4
+    expect(id4).to be < id3
+    expect(id3).to be < id1
+    expect(id1).to be < id2
   end
 end

--- a/spec/features/issue_spec.rb
+++ b/spec/features/issue_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'Dashboard', js: true do
+  it 'differenciates rows with priority bigger than zero' do
+    login_as create(:admin_user)
+
+    5.times do |n|
+      create(:basic_issue, priority: n + 1)
+    end
+
+    6.times do
+      create(:basic_issue)
+    end
+
+    visit '/'
+    click_link 'All'
+    expect(page).to have_selector(:css, '.top-priority', count: 5)
+    expect(page).to have_selector(:css, '.zero-priority', count: 6)
+  end
+end

--- a/spec/requests/api/issues_spec.rb
+++ b/spec/requests/api/issues_spec.rb
@@ -178,6 +178,22 @@ describe Issue do
       expect(api_response.data.attributes.priority).to eq(1)
     end
 
+    it 'change priority from an existing issue' do
+      issue = create(:basic_issue)
+      expect(issue.priority).to eq(0)
+
+      api_update("/issues/#{issue.id}", {
+        type: 'issues',
+        id: issue.id,
+        attributes: {
+          priority: 1
+        }
+      })
+
+      api_get("/issues/#{issue.id}")
+      expect(api_response.data.attributes.priority).to eq(1)
+    end
+
     it 'creates a new issue with custom reason' do  
       expect do
         api_create('/issues', {

--- a/spec/requests/api/issues_spec.rb
+++ b/spec/requests/api/issues_spec.rb
@@ -145,6 +145,22 @@ describe Issue do
       expect(Date.parse(api_response.data.attributes.defer_until)).to eq(defer_until)
     end
 
+    it 'creates a new issue with default priority' do
+      expect do
+        api_create('/issues', {
+          type: 'issues',
+          relationships: { person: {data: {id: person.id, type: 'people'}}}
+        })
+      end.to change{Issue.count}.by(1)
+
+      issue = Issue.find(api_response.data.id)
+      expect(issue.priority).to eq(0)
+
+      api_get("/issues/#{issue.id}")
+      
+      expect(api_response.data.attributes.priority).to eq(0)
+    end
+
     it 'creates a new issue with custom reason' do  
       expect do
         api_create('/issues', {

--- a/spec/requests/api/issues_spec.rb
+++ b/spec/requests/api/issues_spec.rb
@@ -161,6 +161,23 @@ describe Issue do
       expect(api_response.data.attributes.priority).to eq(0)
     end
 
+    it 'creates a new issue with 1 priority' do
+      expect do
+        api_create('/issues', {
+          type: 'issues',
+          attributes: {priority: 1},
+          relationships: { person: {data: {id: person.id, type: 'people'}}}
+        })
+      end.to change{Issue.count}.by(1)
+
+      issue = Issue.find(api_response.data.id)
+      expect(issue.priority).to eq(1)
+
+      api_get("/issues/#{issue.id}")
+      
+      expect(api_response.data.attributes.priority).to eq(1)
+    end
+
     it 'creates a new issue with custom reason' do  
       expect do
         api_create('/issues', {


### PR DESCRIPTION
Agrega un campo que cumpla la función de marcar la prioridad para las issues, identificando todas aquellas con valor mayor a 1 de forma distintiva de las demás en el panel admin.

fixes: https://github.com/bitex-la/storyboard/issues/1240