### PR TITLE
Ignore .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ build-iPhoneSimulator/
 config/settings.yml
 config/appsignal.yml
 .vscode/launch.json
+
+# Ignore IntelliJ IDEs config
+/.idea/


### PR DESCRIPTION
The .idea directory is generated in all projects that are edited using Intellij's IDE RubyMine. This PR adds to .gitignore this directory to avoid accidental commits.