### PR TITLE
Fixes feature specs breaking because of geckodriver incompatibility with modern Firefox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ group :test do
   gem 'rspec-rails'
   gem 'capybara'
   gem 'selenium-webdriver'
-  gem 'geckodriver-helper'
+  gem 'webdrivers', '~> 4.0'
   gem 'factory_bot'
   gem 'faker'
   gem 'database_cleaner'

--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ group :test do
   gem 'rspec-rails'
   gem 'capybara'
   gem 'selenium-webdriver'
-  gem 'webdrivers', '~> 4.0'
+  gem 'webdrivers', '~> 4.4'
   gem 'factory_bot'
   gem 'faker'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,8 +115,6 @@ GEM
       rack
     arbre (1.1.1)
       activesupport (>= 3.0.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.7.2)
@@ -243,8 +241,6 @@ GEM
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
-    geckodriver-helper (0.23.0)
-      archive-zip (~> 0.7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -262,7 +258,6 @@ GEM
       has_scope (~> 0.6)
       railties (>= 4.2, < 5.3)
       responders
-    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
@@ -472,6 +467,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -518,7 +517,6 @@ DEPENDENCIES
   faker
   fast_jsonapi!
   font-awesome-rails
-  geckodriver-helper
   haml
   hashie
   jbuilder (~> 2.5)
@@ -550,6 +548,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers (~> 4.0)
   yajl-ruby
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,7 +548,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-  webdrivers (~> 4.0)
+  webdrivers (~> 4.4)
   yajl-ruby
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ bundle exec rails -s
 ```
 rspec
 ``` 
+
+In order to run feature specs, the suite relies on `geckodriver`. In order to install it for the project, you can do:
+
+```
+RAILS_ENV=test rails webdrivers:geckodriver:update
+```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bundle exec rails -s
 rspec
 ``` 
 
-In order to run feature specs, the suite relies on `geckodriver`. In order to install it for the project, you can do:
+In order to run the feature specs, the suite relies on `geckodriver`. You can run the following command to install it for the project:
 
 ```
 RAILS_ENV=test rails webdrivers:geckodriver:update

--- a/spec/support/webdrivers.rb
+++ b/spec/support/webdrivers.rb
@@ -1,0 +1,4 @@
+require 'webdrivers/geckodriver'
+
+# Firefox
+Webdrivers::Geckodriver.required_version  = '0.27.0'


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/1394

This PR fixes the recurring bug when having a modern Firefox browser with an old version of geckodriver that causes this failure in feature specs:

```
Failure/Error: Unable to find WebDriverError@chrome://marionette/content/error.js to read failed line
     Selenium::WebDriver::Error::InvalidArgumentError:
       Expected "handle" to be a string, got [object Undefined] undefined
     # WebDriverError@chrome://marionette/content/error.js:181:5
     # InvalidArgumentError@chrome://marionette/content/error.js:310:5
     # assert.that/<@chrome://marionette/content/assert.js:460:13
     # assert.string@chrome://marionette/content/assert.js:360:53
     # GeckoDriver.prototype.switchToWindow@chrome://marionette/content/driver.js:1600:10
     # despatch@chrome://marionette/content/server.js:297:40
     # execute@chrome://marionette/content/server.js:267:16
     # onPacket/<@chrome://marionette/content/server.js:240:20
     # onPacket@chrome://marionette/content/server.js:241:9
     # _onJSONObjectReady/<@chrome://marionette/content/transport.js:504:20
```

The workaround for this is upgrading geckodriver, but the `geckodriver-helper` gem is still locked to `0.23.0` which is pretty old (from March 2018). [There is PR](https://github.com/DevicoSolutions/geckodriver-helper/pull/17) to fix this but it has been waiting feedback from the author 2 months ago.

So I replaced the gem with [webdrivers](https://github.com/titusfortner/webdrivers). This gem allows forcing a specific version and provides flexibility since the versions aren't hardcoded in the codebase.