### PR TITLE
Remove useless references to StaticModels::BelongsTo

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,6 +1,4 @@
 class AdminUser < ApplicationRecord
-  include StaticModels::BelongsTo
-
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :recoverable,

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,7 +1,6 @@
 class Issue < ApplicationRecord
   include AASM
   include Loggable
-  StaticModels::BelongsTo
 
   belongs_to :person, optional: true
   validates :person, presence: true

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,7 +1,6 @@
 class Person < ApplicationRecord
   include AASM
   include Loggable
-  StaticModels::BelongsTo
 
   after_create :log_state_new
   after_save :log_if_enabled


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/1398

Both the Person and Issue model reference to `StaticModels::BelongsTo` module but they seem not to be using nor requiring it. Therefore I am removing these lines from the codebase. 