### PR TITLE
Extended length for texts

### DIFF
--- a/app/admin/arbre_helper/html_helper.rb
+++ b/app/admin/arbre_helper/html_helper.rb
@@ -149,7 +149,7 @@ module ArbreHelpers
       end
     end
 
-    def self.strip_and_truncate(length = 40, text)
+    def self.strip_and_truncate(length = 200, text)
       ArbreHelpers::HtmlHelper.strip_html_tags(text).truncate(length, omission:'...')
     end
 

--- a/spec/features/compliance_spec.rb
+++ b/spec/features/compliance_spec.rb
@@ -87,8 +87,8 @@ describe 'an admin user' do
 
     within '.extra_info' do
       expect(page)
-        .to have_content "link: #{"https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n".truncate(40, omission:'...')}"
-      expect(page).to have_content 'title: de 18 mil familias de clase media - P...'
+        .to have_content "link: https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n"
+      expect(page).to have_content 'title: de 18 mil familias de clase media - PDF - DocPlayer'
     end
 
     assert_logging(issue, :update_entity, 7)
@@ -128,8 +128,8 @@ describe 'an admin user' do
     end
 
     within '.extra_info' do
-      expect(page).to have_content "link: #{"https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n".truncate(40, omission:'...')}"
-      expect(page).to have_content 'title: de 18 mil familias de clase media - P...'
+      expect(page).to have_content "link: https://issuu.com/mop_chile0/docs/15_proyectos_de_restauraci_n"
+      expect(page).to have_content 'title: de 18 mil familias de clase media - PDF - DocPlayer'
     end
 
     click_link 'Enable'


### PR DESCRIPTION
Fixes: https://github.com/bitex-la/storyboard/issues/2281

Extiendo el tamaño de estos textos para poder visualizar más detalles. En particular para la respuesta de `Jumio` que se necesitan ver detalles de `rejectReason`.

Adjunto imagen:

![Screenshot from 2021-11-08 15-09-00](https://user-images.githubusercontent.com/89464380/140795390-ae5a249a-e169-48a2-994f-0e4ae3bd9f87.png)


