### PR TITLE
Now it checks for observations for client scope and include issue obs…

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -383,6 +383,7 @@ class Issue < ApplicationRecord
 
   def all_observations
     all = []
+    all << observations.to_a.select { |obs| obs.observable.nil? }
     HAS_MANY.each do |assoc|
       send(assoc).each do |association|
         next unless association
@@ -398,7 +399,7 @@ class Issue < ApplicationRecord
       all << (association.fruit || association).observations
     end
 
-    all
+    all.flatten.select { |obs| obs.client? && obs.new? }
   end
 
   def all_seeds

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -754,4 +754,40 @@ RSpec.describe Issue, type: :model do
       expect(basic_issue.defer_until).to eq defer
     end
   end
+
+  describe '.all_observations' do
+    context 'observations without observable' do
+      let(:issue) { create(:basic_issue, person: create(:empty_person)) }
+
+      it 'only returns observations for client scope' do
+        observation = create(:observation, issue: issue)
+        robot_observation = create(:robot_observation, issue: issue)
+        expect(issue.all_observations).to eq([observation])
+      end
+
+      it 'only returns observations in new state' do
+        observation = create(:observation, issue: issue)
+        answered_observation = create(:observation, issue: issue, reply: 'A reply')
+        expect(issue.all_observations).to eq([observation])
+      end
+    end
+
+    context 'observations with observable' do
+      let(:issue) { create(:basic_issue, person: create(:empty_person)) }
+
+      it 'only returns observations for client scope' do
+        domicile_seed = create(:full_domicile_seed, issue: issue)
+        observation = create(:observation, issue: issue, observable: domicile_seed)
+        robot_observation = create(:robot_observation, issue: issue, observable: domicile_seed)
+        expect(issue.all_observations).to eq([observation])
+      end
+
+      it 'only returns observations in new state' do
+        domicile_seed = create(:full_domicile_seed, issue: issue)
+        observation = create(:observation, issue: issue, observable: domicile_seed)
+        answered_observation = create(:observation, issue: issue, reply: 'A reply', observable: domicile_seed)
+        expect(issue.all_observations).to eq([observation])
+      end
+    end
+  end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -760,14 +760,14 @@ RSpec.describe Issue, type: :model do
       let(:issue) { create(:basic_issue, person: create(:empty_person)) }
 
       it 'only returns observations for client scope' do
-        observation = create(:observation, issue: issue)
-        robot_observation = create(:robot_observation, issue: issue)
+        observation = create(:observation, issue: issue, observable: nil)
+        robot_observation = create(:robot_observation, issue: issue, observable: nil)
         expect(issue.all_observations).to eq([observation])
       end
 
       it 'only returns observations in new state' do
-        observation = create(:observation, issue: issue)
-        answered_observation = create(:observation, issue: issue, reply: 'A reply')
+        observation = create(:observation, issue: issue, observable: nil)
+        answered_observation = create(:observation, issue: issue, reply: 'A reply', observable: nil)
         expect(issue.all_observations).to eq([observation])
       end
     end


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/2284

Agregamos cambios para contemplar observaciones a nivel Issue (no asociadas a un seed) y filtrado para observaciones de scope client y sin respuesta