### PR TITLE
Removed hardcoded message for empty observations

### DIFF
--- a/app/controllers/api/attachments_controller.rb
+++ b/app/controllers/api/attachments_controller.rb
@@ -12,7 +12,6 @@ class Api::AttachmentsController < Api::EntityController
   def create
     if issue_token
       check_validity_token(params[:issue_token_id])
-      update_observations_if_empty(params[:observation_id])
     end
 
     map_and_save(201)
@@ -52,10 +51,5 @@ class Api::AttachmentsController < Api::EntityController
 
   def issue_token
     params[:issue_token_id].present?
-  end
-
-  def update_observations_if_empty(observation_id)
-    observation = Observation.find(observation_id)
-    observation.update!(reply: 'Reply in Attachment') if observation.reply.blank?
   end
 end

--- a/spec/requests/api/issue_tokens_spec.rb
+++ b/spec/requests/api/issue_tokens_spec.rb
@@ -146,34 +146,6 @@ describe IssueToken do
     end
   end
 
-  it 'fill observations reply if sending an attachment and observation is empty' do
-    issue_token = IssueToken.where(issue: issue).first
-    observations = issue_token.observations
-
-    observations.each do |observation|
-      api_create_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/attachments",
-        type: 'attachments',
-        relationships: { attached_to_seed: { data: { id: seed.id, type: 'natural_docket_seeds' } } },
-        attributes: {
-          document: "data:#{mime_for(:jpg)};base64,#{bytes_for('jpg')}",
-          document_file_name: 'áñçfile微信图片.jpg',
-          document_content_type: mime_for(:jpg)
-        }
-      )
-    end
-
-    api_get "/issues/#{issue.id}"
-    expect(api_response.data.attributes.state).to eq('answered')
-
-    observations.each do |observation|
-      api_get("/observations/#{observation.id}")
-      expect(
-        api_response.data.attributes.reply
-      ).to eq('Reply in Attachment')
-    end
-  end
-
   it 'can not replies to an observation when token is invalid' do
     issue_token = IssueToken.where(issue: issue).first
 


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/2388

# This PR
Removemos el código que agrega un mensaje de respuesta a las `Observations` desde el endpoint de `Attachments`, ya que no debería ser un caso posible porque las respuestas son [mandatorias](https://docs.google.com/document/d/1424bwDz9J4JVVekrTXyERd4dRAqL2nKxKqk0JaqSYOI).