### PR TITLE
Issue returns latest token

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -8,7 +8,7 @@ class Issue < ApplicationRecord
 
   has_many :issue_taggings
   has_many :tags, through: :issue_taggings
-  has_one :issue_token
+  has_one :issue_token, -> { order id: :desc }
   accepts_nested_attributes_for :issue_taggings, allow_destroy: true
 
   ransack_alias :state, :aasm_state

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -99,6 +99,13 @@ RSpec.describe Issue, type: :model do
     expect(Issue.last.defer_until).to eq Date.current
   end
 
+  it 'returns latest issue_token' do
+    first_token = IssueToken.create!(issue: basic_issue)
+    second_token = IssueToken.create!(issue: basic_issue)
+    expect(basic_issue.reload.issue_token).not_to eq first_token
+    expect(basic_issue.reload.issue_token).to eq second_token
+  end
+
   describe 'affinity_to_tag' do
     let(:issue) { create(:basic_issue, person: create(:empty_person)) } 
     let(:related_person) { create(:empty_person) } 


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/2387

# This PR
Ordenamos la `has_one` relation con `IssueToken` para que retorne el más reciente.