### PR TITLE
Multiple attachment upload

### DIFF
--- a/app/admin/arbre_helper/attachment.rb
+++ b/app/admin/arbre_helper/attachment.rb
@@ -42,6 +42,8 @@ module ArbreHelpers
               ArbreHelpers::Attachment.preview(self, a)
             }.to_s
           )
+        else
+          af.input :document, as: :file, label: "Attachment"
         end
       end
       form.input :multiple_documents, as: :file, label: "Add Attachments", input_html: { multiple: true }

--- a/app/admin/arbre_helper/attachment.rb
+++ b/app/admin/arbre_helper/attachment.rb
@@ -46,7 +46,7 @@ module ArbreHelpers
           af.input :document, as: :file, label: "Attachment"
         end
       end
-      form.input :multiple_documents, as: :file, label: "Add Attachments", input_html: { multiple: true }
+      form.input :multiple_documents, as: :file, label: "Add Attachments", input_html: { multiple: true }, hint: "Max. size per file 10MB"
     end
 
     def self.attachments_list(context, attachments)

--- a/app/admin/arbre_helper/attachment.rb
+++ b/app/admin/arbre_helper/attachment.rb
@@ -33,7 +33,7 @@ module ArbreHelpers
     end
 
     def self.has_many_attachments(context, form)
-      ArbreHelpers::Form.has_many_form context, form, :attachments do |af, ctx|
+      ArbreHelpers::Form.has_many_form context, form, :attachments, new_button_enabled: false do |af, ctx|
         a = af.object
         if a.persisted?
           af.input :_destroy, as: :boolean, required: false, label: 'Remove', class: "check_box_remove"
@@ -42,11 +42,9 @@ module ArbreHelpers
               ArbreHelpers::Attachment.preview(self, a)
             }.to_s
           )
-        else
-          af.input :document, as: :file, label: "Attachment"
         end
       end
-      form.input :multiple_documents, as: :file, label: "Attachments", input_html: { multiple: true }
+      form.input :multiple_documents, as: :file, label: "Add Attachments", input_html: { multiple: true }
     end
 
     def self.attachments_list(context, attachments)

--- a/app/admin/arbre_helper/attachment.rb
+++ b/app/admin/arbre_helper/attachment.rb
@@ -33,7 +33,7 @@ module ArbreHelpers
     end
 
     def self.has_many_attachments(context, form)
-      ArbreHelpers::Form.has_many_form context, form, :attachments do |af, ctx|  
+      ArbreHelpers::Form.has_many_form context, form, :attachments do |af, ctx|
         a = af.object
         if a.persisted?
           af.input :_destroy, as: :boolean, required: false, label: 'Remove', class: "check_box_remove"
@@ -45,7 +45,8 @@ module ArbreHelpers
         else
           af.input :document, as: :file, label: "Attachment"
         end
-      end  
+      end
+      form.input :multiple_documents, as: :file, label: "Attachments", input_html: { multiple: true }
     end
 
     def self.attachments_list(context, attachments)

--- a/app/admin/arbre_helper/form.rb
+++ b/app/admin/arbre_helper/form.rb
@@ -6,7 +6,8 @@ module ArbreHelpers
     end
 
     def self.has_many_form(context, builder, relationship, extra={}, &fields)
-      new_button_text = extra[:new_button_text] || true
+      new_button_enabled = extra.fetch(:new_button_enabled, true)
+      new_button_text = new_button_enabled ? extra[:new_button_text] || true : false
       builder.has_many relationship,new_record: new_button_text,
         class: "#{'can_remove' unless extra[:cant_remove]}" do |f|    
         instance_exec(f, context, &fields)

--- a/app/admin/arbre_helper/form.rb
+++ b/app/admin/arbre_helper/form.rb
@@ -6,8 +6,9 @@ module ArbreHelpers
     end
 
     def self.has_many_form(context, builder, relationship, extra={}, &fields)
-      new_button_text = extra[:new_button_text] || true
-      builder.has_many relationship,new_record: new_button_text, 
+      new_button_visible = extra.key?(:new_button_visible) ? extra[:new_button_visible] : true
+      new_button_text = new_button_visible ? extra[:new_button_text] || true : false
+      builder.has_many relationship,new_record: new_button_text,
         class: "#{'can_remove' unless extra[:cant_remove]}" do |f|    
         instance_exec(f, context, &fields)
         if f.object.persisted? && !extra[:cant_remove]

--- a/app/admin/arbre_helper/form.rb
+++ b/app/admin/arbre_helper/form.rb
@@ -6,8 +6,7 @@ module ArbreHelpers
     end
 
     def self.has_many_form(context, builder, relationship, extra={}, &fields)
-      new_button_visible = extra.key?(:new_button_visible) ? extra[:new_button_visible] : true
-      new_button_text = new_button_visible ? extra[:new_button_text] || true : false
+      new_button_text = extra[:new_button_text] || true
       builder.has_many relationship,new_record: new_button_text,
         class: "#{'can_remove' unless extra[:cant_remove]}" do |f|    
         instance_exec(f, context, &fields)

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -11,6 +11,8 @@ class Attachment < ApplicationRecord
   validates :person, presence: true
   validate :person_cannot_be_removed_once_set
 
+  after_validation :clean_paperclip_errors
+
   before_save :classify_type
   after_save{ person.expire_action_cache }
 
@@ -46,7 +48,7 @@ class Attachment < ApplicationRecord
                                       application/vnd.ms-excel
                                       application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
                                     ],
-                                    message: 'File uploaded has an invalid content type.'
+                                    message: lambda {|attachment, metadata| "File #{attachment.document_file_name} has an invalid content type." }
 
   validates_attachment_file_name :document,
                                  matches: [
@@ -61,11 +63,11 @@ class Attachment < ApplicationRecord
                                    /xls|XLS\z/,
                                    /xlsx|XLSX\z/
                                  ],
-                                 message: 'File uploaded contains an invalid file name.'
+                                 message: lambda {|attachment, metadata| "File #{attachment.document_file_name} contains an invalid file name." }
 
   validates_attachment_size :document,
                             less_than: 10.megabytes,
-                            message: 'File size must be lower than 10MB.'
+                            message: lambda {|attachment, metadata| "File #{attachment.document_file_name} size must be lower than 10MB." }
 
   def attached_to_something
     return unless attached_to.nil?
@@ -114,6 +116,10 @@ class Attachment < ApplicationRecord
 
   def issue
     attached_to_seed.try(:issue)
+  end
+
+  def clean_paperclip_errors
+    errors.delete(:document)
   end
 
   private

--- a/lib/garden.rb
+++ b/lib/garden.rb
@@ -156,7 +156,7 @@ module Garden
     end
 
     def multiple_documents=(files = [])
-      files.each { |file| attachments.create(document: file) }
+      files.each { |file| attachments.new(document: file) }
     end
   end
 

--- a/lib/garden.rb
+++ b/lib/garden.rb
@@ -154,6 +154,10 @@ module Garden
       new_issue.add_seeds_replacing([fruit])
       new_issue.save!
     end
+
+    def multiple_documents=(files = [])
+      files.each { |file| attachments.create(document: file) }
+    end
   end
 
   module Fruit

--- a/spec/features/compliance_spec.rb
+++ b/spec/features/compliance_spec.rb
@@ -488,8 +488,7 @@ describe 'an admin user' do
     )
 
     within(".has_many_container.identification_seeds") do
-      click_link "Add New Attachment"
-      fill_attachment('identification_seeds', 'jpg')
+      fill_multiple_attachments('identification_seeds', 'jpg')
     end
 
     find(:css, '#issue_identification_seeds_attributes_0_copy_attachments').set true
@@ -516,8 +515,7 @@ describe 'an admin user' do
     )
 
     within(".has_many_container.domicile_seeds") do
-      click_link "Add New Attachment"
-      fill_attachment('domicile_seeds', 'jpg')
+      fill_multiple_attachments('domicile_seeds', 'jpg')
     end
 
     find('li[title="Allowances"] a').click
@@ -538,8 +536,7 @@ describe 'an admin user' do
     )
 
     within(".has_many_container.allowance_seeds") do
-      click_link "Add New Attachment"
-      fill_attachment('allowance_seeds', 'gif')
+      fill_multiple_attachments('allowance_seeds', 'gif')
     end
 
     find('li[title="Natural dockets"] a').click
@@ -561,8 +558,7 @@ describe 'an admin user' do
     }, false)
 
     within("#natural_docket_seed") do
-      click_link "Add New Attachment"
-      fill_attachment('natural_docket_seed', 'png', false)
+      fill_multiple_attachments('natural_docket_seed', 'png', false)
     end
 
     add_observation(observation_reason, 'Please check this guy on world check')
@@ -886,8 +882,7 @@ describe 'an admin user' do
         })
 
         find(:css, "#issue_domicile_seeds_attributes_0_attachments_attributes_0__destroy").set(true)
-        click_link "Add New Attachment"
-        fill_attachment('domicile_seeds', 'gif', true, 0, 18)
+        fill_multiple_attachments('domicile_seeds', 'gif', true, 0, 18)
       end
 
       click_button "Update Issue"
@@ -935,8 +930,7 @@ describe 'an admin user' do
       )
 
       within(".has_many_container.identification_seeds") do
-        click_link "Add New Attachment"
-        fill_attachment('identification_seeds', 'jpg')
+        fill_multiple_attachments('identification_seeds', 'jpg')
       end
 
       find('li[title="Domiciles"] a').click
@@ -954,8 +948,7 @@ describe 'an admin user' do
         apartment: 'C'
       })
       within(".has_many_container.domicile_seeds fieldset:nth-of-type(1)") do
-        click_link "Add New Attachment"
-        fill_attachment('domicile_seeds', 'jpg')
+        fill_multiple_attachments('domicile_seeds', 'jpg')
       end
 
       click_button "Update Issue"
@@ -1024,10 +1017,7 @@ describe 'an admin user' do
       )
 
       within(".has_many_container.identification_seeds") do
-        within first(".has_many_container.attachments") do
-          click_link "Add New Attachment"
-          fill_attachment('identification_seeds', 'jpg', true, 0, 18)
-        end
+        fill_multiple_attachments('identification_seeds', 'jpg', true, 0, 18)
       end
 
       click_button 'Update Issue'
@@ -1191,195 +1181,5 @@ describe 'an admin user' do
   it 'exports the customer data signed by bitex' do
     pending
     fail
-  end
-
-  context 'multiple attachments input' do
-    it "Edits a customer by creating a new issue" do
-      observation_reason = create(:human_world_check_reason)
-      person = create(:full_natural_person)
-      login_as compliance_admin_user
-
-      click_link 'People'
-      click_link 'All'
-
-      within("tr[id='person_#{person.id}'] td[class='col col-actions']") do
-        click_link('View')
-      end
-
-      click_link "Add Person Information"
-      click_button "Create new issue"
-
-      find('li[title="Identifications"] a').click
-      click_link "Add New Identification seed"
-      fill_seed("identification",{
-        number: '123456789',
-        issuer: 'AR'
-      })
-
-      select_with_search(
-        '#issue_identification_seeds_attributes_0_identification_kind_id_input',
-        'national_id'
-      )
-
-      person.identifications.reload
-
-      select_with_search(
-        '#issue_identification_seeds_attributes_0_replaces_input',
-        person.identifications.first.name
-      )
-
-      within(".has_many_container.identification_seeds") do
-        click_link "Add New Attachment"
-        fill_multiple_attachments('identification_seeds', 'jpg')
-      end
-
-      find(:css, '#issue_identification_seeds_attributes_0_copy_attachments').set true
-
-      find('li[title="Domiciles"] a').click
-      click_link "Add New Domicile seed"
-
-      fill_seed('domicile', {
-        country: 'AR',
-        state: 'Buenos Aires',
-        city: 'C.A.B.A',
-        street_address: 'Monroe',
-        street_number: '4567',
-        postal_code: '1657',
-        floor: '1',
-        apartment: 'C'
-      })
-
-      person.domiciles.reload
-
-      select_with_search(
-        '#issue_domicile_seeds_attributes_0_replaces_input',
-        person.domiciles.first.name
-      )
-
-      within(".has_many_container.domicile_seeds") do
-        click_link "Add New Attachment"
-        fill_multiple_attachments('domicile_seeds', 'jpg')
-      end
-
-      find('li[title="Allowances"] a').click
-      click_link "Add New Allowance seed"
-
-      select_with_search(
-        '#issue_allowance_seeds_attributes_0_kind_id_input',
-        'us_dollar'
-      )
-      fill_seed("allowance", {
-        amount: "100"
-      })
-
-      person.allowances.reload
-      select_with_search(
-        '#issue_allowance_seeds_attributes_0_replaces_input',
-        person.allowances.first.name
-      )
-
-      within(".has_many_container.allowance_seeds") do
-        click_link "Add New Attachment"
-        fill_multiple_attachments('allowance_seeds', 'gif')
-      end
-
-      find('li[title="Natural dockets"] a').click
-
-      select_with_search(
-        '#issue_natural_docket_seed_attributes_marital_status_id_input',
-        'married'
-      )
-      select_with_search(
-        '#issue_natural_docket_seed_attributes_gender_id_input',
-        'male'
-      )
-
-      fill_seed("natural_docket", {
-        nationality: 'AR',
-        first_name: "Lionel",
-        last_name: "Higuain",
-        birth_date: "1985-01-01"
-      }, false)
-
-      within("#natural_docket_seed") do
-        click_link "Add New Attachment"
-        fill_multiple_attachments('natural_docket_seed', 'png', false)
-      end
-
-      add_observation(observation_reason, 'Please check this guy on world check')
-
-      click_button "Update Issue"
-      click_link "Edit"
-
-      issue = Issue.last
-      assert_logging(issue, :create_entity, 1)
-      assert_logging(issue.reload, :observe_issue, 1, false)
-      observation = Observation.last
-      issue.should be_observed
-      observation.should be_new
-
-      find('li[title="Observations"] a').click
-      fill_in 'issue[observations_attributes][0][reply]',
-              with: '0 hits go ahead!!!'
-      click_button "Update Issue"
-      click_link "Edit"
-
-      assert_logging(issue, :update_entity, 7)
-      issue.reload.should be_answered
-      observation.reload.should be_answered
-
-      Timecop.travel 2.days.from_now
-
-      add_observation(1, observation_reason, 'Please check this guy on FBI database')
-      add_observation(2, observation_reason, 'Please check this on SII')
-
-      click_button "Update Issue"
-      click_link "Edit"
-
-      assert_logging(issue.reload, :observe_issue, 2)
-
-      find('li[title="Observations"] a').click
-
-      fill_in 'issue[observations_attributes][1][reply]',
-              with: '0 hits go ahead!!!'
-
-      fill_in 'issue[observations_attributes][2][reply]',
-              with: 'He is OK on SII'
-
-      click_button "Update Issue"
-
-      click_link "Approve"
-
-      issue.reload.should be_approved
-      assert_logging(person, :enable_person, 1, false)
-
-      old_domicile = Domicile.first
-      new_domicile = Domicile.last
-      old_identification = Identification.first
-      new_identification = Identification.last
-      old_allowance = Allowance.first
-      new_allowance = Allowance.last
-      old_natural_docket = NaturalDocket.first
-      new_natural_docket = NaturalDocket.last
-
-      old_domicile.replaced_by_id.should == new_domicile.id
-      new_domicile.replaced_by_id.should be_nil
-
-      old_identification.replaced_by_id.should == new_identification.id
-      new_identification.replaced_by_id.should be_nil
-
-      old_natural_docket.replaced_by_id.should == new_natural_docket.id
-      new_natural_docket.replaced_by_id.should be_nil
-
-      old_allowance.replaced_by_id.should == new_allowance.id
-      new_allowance.replaced_by_id.should be_nil
-
-      # Here we validate that attachments are copy to the new fruit (when applies)
-      new_identification.attachments.count.should == 19
-      new_natural_docket.attachments.count.should == 1
-
-      person.should be_enabled
-      expect(person.state).to eq('enabled')
-    end
   end
 end

--- a/spec/features/compliance_spec.rb
+++ b/spec/features/compliance_spec.rb
@@ -488,7 +488,7 @@ describe 'an admin user' do
     )
 
     within(".has_many_container.identification_seeds") do
-      fill_multiple_attachments('identification_seeds', 'jpg')
+      fill_attachment('identification_seeds', 'jpg')
     end
 
     find(:css, '#issue_identification_seeds_attributes_0_copy_attachments').set true
@@ -515,7 +515,7 @@ describe 'an admin user' do
     )
 
     within(".has_many_container.domicile_seeds") do
-      fill_multiple_attachments('domicile_seeds', 'jpg')
+      fill_attachment('domicile_seeds', 'jpg')
     end
 
     find('li[title="Allowances"] a').click
@@ -536,7 +536,7 @@ describe 'an admin user' do
     )
 
     within(".has_many_container.allowance_seeds") do
-      fill_multiple_attachments('allowance_seeds', 'gif')
+      fill_attachment('allowance_seeds', 'gif')
     end
 
     find('li[title="Natural dockets"] a').click
@@ -558,7 +558,7 @@ describe 'an admin user' do
     }, false)
 
     within("#natural_docket_seed") do
-      fill_multiple_attachments('natural_docket_seed', 'png', false)
+      fill_attachment('natural_docket_seed', 'png', false)
     end
 
     add_observation(observation_reason, 'Please check this guy on world check')
@@ -882,7 +882,7 @@ describe 'an admin user' do
         })
 
         find(:css, "#issue_domicile_seeds_attributes_0_attachments_attributes_0__destroy").set(true)
-        fill_multiple_attachments('domicile_seeds', 'gif', true, 0, 18)
+        fill_attachment('domicile_seeds', 'gif', true)
       end
 
       click_button "Update Issue"
@@ -930,7 +930,7 @@ describe 'an admin user' do
       )
 
       within(".has_many_container.identification_seeds") do
-        fill_multiple_attachments('identification_seeds', 'jpg')
+        fill_attachment('identification_seeds', 'jpg')
       end
 
       find('li[title="Domiciles"] a').click
@@ -948,7 +948,7 @@ describe 'an admin user' do
         apartment: 'C'
       })
       within(".has_many_container.domicile_seeds fieldset:nth-of-type(1)") do
-        fill_multiple_attachments('domicile_seeds', 'jpg')
+        fill_attachment('domicile_seeds', 'jpg')
       end
 
       click_button "Update Issue"
@@ -1017,7 +1017,7 @@ describe 'an admin user' do
       )
 
       within(".has_many_container.identification_seeds") do
-        fill_multiple_attachments('identification_seeds', 'jpg', true, 0, 18)
+        fill_attachment('identification_seeds', 'jpg', true)
       end
 
       click_button 'Update Issue'

--- a/spec/helpers/feature_helpers.rb
+++ b/spec/helpers/feature_helpers.rb
@@ -37,24 +37,31 @@ module FeatureHelpers
       .set(0)
   end
 
-  def fill_multiple_attachments(kind, ext = 'jpg', has_many = true, index = 0, accented = false)
+  def fill_attachment(kind, ext = 'jpg', has_many = true, accented = false)
     wait_for_ajax
-    path = if has_many
-             "issue[#{kind}_attributes][#{index}][multiple_documents][]"
-           else
-             "issue[#{kind}_attributes][multiple_documents][]"
-           end
-    filename = if accented
-                 "./spec/fixtures/files/áñ_simple_微信图片.#{ext}"
-               else
-                 if ext == ext.upcase
-                   "./spec/fixtures/files/simple_upper.#{ext}"
-                 else
-                   "./spec/fixtures/files/simple.#{ext}"
-                 end
-               end
-    attach_file(path,
-                File.absolute_path(filename), wait: 10.seconds)
+    path = build_attachment_path(has_many, kind)
+    filename = build_attachment_filename(accented, ext)
+    attach_file(path, File.absolute_path(filename), wait: 10.seconds)
+  end
+
+  def build_attachment_path(has_many, kind, index = 0)
+    if has_many
+      "issue[#{kind}_attributes][#{index}][multiple_documents][]"
+    else
+      "issue[#{kind}_attributes][multiple_documents][]"
+    end
+  end
+
+  def build_attachment_filename(accented, ext)
+    if accented
+      "./spec/fixtures/files/áñ_simple_微信图片.#{ext}"
+    else
+      if ext == ext.upcase
+        "./spec/fixtures/files/simple_upper.#{ext}"
+      else
+        "./spec/fixtures/files/simple.#{ext}"
+      end
+    end
   end
 
   def add_affinities(related_ones, kind, start_index)
@@ -115,7 +122,7 @@ module FeatureHelpers
     )
 
     within(".has_many_container.identification_seeds") do
-      fill_multiple_attachments('identification_seeds', 'jpg', true, 0, true)
+      fill_attachment('identification_seeds', 'jpg', true, true)
     end
 
     find('li[title="Emails"] a').click
@@ -156,7 +163,7 @@ module FeatureHelpers
       apartment: 'C'
     })
     within(".has_many_container.domicile_seeds") do
-      fill_multiple_attachments('domicile_seeds', 'jpg', true, 0, true)
+      fill_attachment('domicile_seeds', 'jpg', true, true)
     end
 
     find('li[title="Allowances"] a').click 
@@ -172,7 +179,7 @@ module FeatureHelpers
     })
 
     within(".has_many_container.allowance_seeds") do
-      fill_multiple_attachments('allowance_seeds', 'gif', true, 0, true)
+      fill_attachment('allowance_seeds', 'gif', true, true)
     end
 
     find('li[title="Natural dockets"] a').click 
@@ -199,7 +206,7 @@ module FeatureHelpers
     }, false)
 
     within("#natural_docket_seed") do
-      fill_multiple_attachments('natural_docket_seed', 'png', false)
+      fill_attachment('natural_docket_seed', 'png', false)
     end
 
     find('li[title="Risk scores"] a').click  
@@ -213,7 +220,7 @@ module FeatureHelpers
     })
 
     within(".has_many_container.risk_score_seeds") do
-      fill_multiple_attachments('risk_score_seeds', 'gif', true, 0,true)
+      fill_attachment('risk_score_seeds', 'gif', true, true)
     end
   end
 

--- a/spec/helpers/feature_helpers.rb
+++ b/spec/helpers/feature_helpers.rb
@@ -57,6 +57,26 @@ module FeatureHelpers
         File.absolute_path(filename), wait: 10.seconds)
   end
 
+  def fill_multiple_attachments(kind, ext = 'jpg', has_many = true, index = 0, accented = false)
+    wait_for_ajax
+    path = if has_many
+             "issue[#{kind}_attributes][#{index}][multiple_documents][]"
+           else
+             "issue[#{kind}_attributes][multiple_documents][]"
+           end
+    filename = if accented
+                 "./spec/fixtures/files/áñ_simple_微信图片.#{ext}"
+               else
+                 if ext == ext.upcase
+                   "./spec/fixtures/files/simple_upper.#{ext}"
+                 else
+                   "./spec/fixtures/files/simple.#{ext}"
+                 end
+               end
+    attach_file(path,
+                File.absolute_path(filename), wait: 10.seconds)
+  end
+
   def add_affinities(related_ones, kind, start_index)
     related_ones.each_with_index do |related, index|
       click_link "Add New Affinity seed"

--- a/spec/helpers/feature_helpers.rb
+++ b/spec/helpers/feature_helpers.rb
@@ -37,26 +37,6 @@ module FeatureHelpers
       .set(0)
   end
 
-  def fill_attachment(kind, ext = 'jpg', has_many = true, index = 0, att_index = 0, accented = false)
-    wait_for_ajax
-    path = if has_many
-      "issue[#{kind}_attributes][#{index}][attachments_attributes][#{att_index}][document]"
-    else
-      "issue[#{kind}_attributes][attachments_attributes][#{att_index}][document]"
-    end
-    filename = if accented
-      "./spec/fixtures/files/áñ_simple_微信图片.#{ext}"
-    else
-      if ext == ext.upcase
-        "./spec/fixtures/files/simple_upper.#{ext}"
-      else 
-        "./spec/fixtures/files/simple.#{ext}"
-      end
-    end
-    attach_file(path,
-        File.absolute_path(filename), wait: 10.seconds)
-  end
-
   def fill_multiple_attachments(kind, ext = 'jpg', has_many = true, index = 0, accented = false)
     wait_for_ajax
     path = if has_many
@@ -135,8 +115,7 @@ module FeatureHelpers
     )
 
     within(".has_many_container.identification_seeds") do
-      click_link "Add New Attachment"
-      fill_attachment('identification_seeds', 'jpg', true, 0, 0, true)
+      fill_multiple_attachments('identification_seeds', 'jpg', true, 0, true)
     end
 
     find('li[title="Emails"] a').click
@@ -177,8 +156,7 @@ module FeatureHelpers
       apartment: 'C'
     })
     within(".has_many_container.domicile_seeds") do
-      click_link "Add New Attachment"
-      fill_attachment('domicile_seeds', 'jpg', true, 0, 0, true)
+      fill_multiple_attachments('domicile_seeds', 'jpg', true, 0, true)
     end
 
     find('li[title="Allowances"] a').click 
@@ -194,8 +172,7 @@ module FeatureHelpers
     })
 
     within(".has_many_container.allowance_seeds") do
-      click_link "Add New Attachment"
-      fill_attachment('allowance_seeds', 'gif', true, 0, 0, true)
+      fill_multiple_attachments('allowance_seeds', 'gif', true, 0, true)
     end
 
     find('li[title="Natural dockets"] a').click 
@@ -222,8 +199,7 @@ module FeatureHelpers
     }, false)
 
     within("#natural_docket_seed") do
-      find('.has_many_container.attachments').click_link("Add New Attachment")
-      fill_attachment('natural_docket_seed', 'png', false)
+      fill_multiple_attachments('natural_docket_seed', 'png', false)
     end
 
     find('li[title="Risk scores"] a').click  
@@ -237,8 +213,7 @@ module FeatureHelpers
     })
 
     within(".has_many_container.risk_score_seeds") do
-      click_link "Add New Attachment"
-      fill_attachment('risk_score_seeds', 'gif', true, 0, 0, true)
+      fill_multiple_attachments('risk_score_seeds', 'gif', true, 0,true)
     end
   end
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -67,6 +67,6 @@ describe Attachment do
     a = build(:exceeding_size_attachment, thing: phone)
     expect(a.attached_to_fruit).to eq phone
     a.should_not be_valid
-    expect(a.errors[:document]).to eq ['File size must be lower than 10MB.']
+    expect(a.errors[:document_file_size]).to eq ['File exceeding_size.doc size must be lower than 10MB.']
   end
 end


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/2412

# Considerations
Con estos cambios se agrega un input de archivos multiples a nivel `Seed`. Podría reemplazar directamente los inputs individuales por `Attachment` pero implicaría ajustar los feature_specs.

Input:

![Screenshot from 2021-12-16 17-41-33](https://user-images.githubusercontent.com/89464380/146604374-d33a1179-a7d8-4e57-9768-8d2452088b04.png)

