### PR TITLE
Added reply validations for observations endpoint

### DIFF
--- a/app/controllers/api/entity_controller.rb
+++ b/app/controllers/api/entity_controller.rb
@@ -21,11 +21,11 @@ class Api::EntityController < Api::ReadOnlyEntityController
 
   protected
 
-  def map_and_save(success_code)
+  def map_and_save(success_code, context = nil)
     mapper = get_mapper
     return jsonapi_422 unless mapper.data
 
-    if mapper.data.save
+   if mapper.data.save(context: context)
       jsonapi_response mapper.data, options_for_response, success_code
     else
       json_response mapper.all_errors, 422

--- a/app/controllers/api/observations_controller.rb
+++ b/app/controllers/api/observations_controller.rb
@@ -9,19 +9,7 @@ class Api::ObservationsController < Api::EntityController
     params[:data][:id] = resource.id
     check_validity_token(params[:issue_token_id], params[:data][:id]) if issue_token
 
-    map_and_save(200)
-  rescue NoMethodError
-    jsonapi_422
-  rescue IssueTokenNotValidError
-    jsonapi_error(410, 'invalid token')
-  rescue ActiveRecord::RecordNotFound
-    jsonapi_error(404, 'can not find observation')
-  end
-
-  def reply
-    check_validity_token(params[:issue_token_id], params[:data][:id]) if issue_token
-
-    map_and_save(200, :observation_reply)
+    map_and_save(200, context)
   rescue NoMethodError
     jsonapi_422
   rescue IssueTokenNotValidError
@@ -58,6 +46,10 @@ class Api::ObservationsController < Api::EntityController
     IssueToken
       .includes(:observations)
       .where(observations: { id: observation_id }).find_by_token!(token)
+  end
+
+  def context
+    :observation_reply if params[:data][:attributes].key?(:reply)
   end
 
   def issue_token

--- a/app/controllers/api/observations_controller.rb
+++ b/app/controllers/api/observations_controller.rb
@@ -9,7 +9,7 @@ class Api::ObservationsController < Api::EntityController
     params[:data][:id] = resource.id
     check_validity_token(params[:issue_token_id], params[:data][:id]) if issue_token
 
-    map_and_save(200)
+    map_and_save(200, :observation_reply)
   rescue NoMethodError
     jsonapi_422
   rescue IssueTokenNotValidError

--- a/app/controllers/api/observations_controller.rb
+++ b/app/controllers/api/observations_controller.rb
@@ -49,7 +49,7 @@ class Api::ObservationsController < Api::EntityController
   end
 
   def context
-    :observation_reply if params[:data][:attributes].key?(:reply)
+    :observation_reply if params.dig(:data, :attributes, :reply)
   end
 
   def issue_token

--- a/app/controllers/api/observations_controller.rb
+++ b/app/controllers/api/observations_controller.rb
@@ -9,6 +9,18 @@ class Api::ObservationsController < Api::EntityController
     params[:data][:id] = resource.id
     check_validity_token(params[:issue_token_id], params[:data][:id]) if issue_token
 
+    map_and_save(200)
+  rescue NoMethodError
+    jsonapi_422
+  rescue IssueTokenNotValidError
+    jsonapi_error(410, 'invalid token')
+  rescue ActiveRecord::RecordNotFound
+    jsonapi_error(404, 'can not find observation')
+  end
+
+  def reply
+    check_validity_token(params[:issue_token_id], params[:data][:id]) if issue_token
+
     map_and_save(200, :observation_reply)
   rescue NoMethodError
     jsonapi_422

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -25,6 +25,7 @@ class Observation < ApplicationRecord
 
   validate :validate_scope_integrity
   validate :validate_issue_correspondence
+  validates :reply, presence: true, on: :observation_reply
 
   # We add this default_scope to allow others default_scopes
   # to cascade and apply admin taggings rules to the current query

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,7 @@ Rails.application.routes.draw do
     resources :issue_tokens do
       get :show_by_token
       resources :observations, only: [:update] do
+        match :reply, via: [:put, :patch]
         resources :attachments, only: [:create]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,7 +122,6 @@ Rails.application.routes.draw do
     resources :issue_tokens do
       get :show_by_token
       resources :observations, only: [:update] do
-        match :reply, via: [:put, :patch]
         resources :attachments, only: [:create]
       end
     end

--- a/spec/features/compliance_spec.rb
+++ b/spec/features/compliance_spec.rb
@@ -788,7 +788,7 @@ describe 'an admin user' do
     api_update "/observations/#{wc_observation.id}", {
       type: 'observations',
       id: wc_observation.id,
-      attributes: {reply: nil}
+      attributes: {reply: 'Ok'}
     }
 
     click_button 'Update Issue'

--- a/spec/requests/api/issue_tokens_spec.rb
+++ b/spec/requests/api/issue_tokens_spec.rb
@@ -44,7 +44,7 @@ describe IssueToken do
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
         type: 'observations',
         id: observation.id,
         attributes: { reply: 'Some reply here' }
@@ -62,7 +62,7 @@ describe IssueToken do
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
         type: 'observations',
         id: observation.id,
         attributes: { reply: 'Some reply here' }
@@ -81,13 +81,30 @@ describe IssueToken do
     end
   end
 
+  it 'returns an error if reply is empty' do
+    issue_token = IssueToken.where(issue: issue).first
+    observations = issue_token.observations
+
+    observations.each do |observation|
+      api_update_issue_token(
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+        {
+          type: 'observations',
+          id: observation.id,
+          attributes: { reply: '   ' }
+        },
+        422
+      )
+    end
+  end
+
   it 'fails if replies to an already answered observation' do
     issue_token = IssueToken.where(issue: issue).first
     observations = issue_token.observations
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
         type: 'observations',
         id: observation.id,
         attributes: { reply: 'Some reply here' }
@@ -97,7 +114,7 @@ describe IssueToken do
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
         {
           type: 'observations',
           id: observation.id,
@@ -126,7 +143,7 @@ describe IssueToken do
       )
 
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
         type: 'observations',
         id: observation.id,
         attributes: { reply: 'Some reply here' }
@@ -151,7 +168,7 @@ describe IssueToken do
     issue_token.observations.each do |observation|
       Timecop.travel 31.days.from_now
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
         {
           type: 'observations',
           id: observation.id,
@@ -166,7 +183,7 @@ describe IssueToken do
     issue_token = IssueToken.where(issue: issue).first
     observation = create(:observation, issue: create(:basic_issue))
     api_update_issue_token(
-      "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
+      "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
       {
         type: 'observations',
         id: observation.id,
@@ -181,7 +198,7 @@ describe IssueToken do
     observation = issue_token.observations.first
 
     api_update_issue_token(
-      "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
+      "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
       type: 'observations',
       id: observation.id,
       attributes: { reply: 'Some reply here' }

--- a/spec/requests/api/issue_tokens_spec.rb
+++ b/spec/requests/api/issue_tokens_spec.rb
@@ -44,7 +44,7 @@ describe IssueToken do
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
         type: 'observations',
         id: observation.id,
         attributes: { reply: 'Some reply here' }
@@ -62,7 +62,7 @@ describe IssueToken do
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
         type: 'observations',
         id: observation.id,
         attributes: { reply: 'Some reply here' }
@@ -87,7 +87,7 @@ describe IssueToken do
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
         {
           type: 'observations',
           id: observation.id,
@@ -104,7 +104,7 @@ describe IssueToken do
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
         type: 'observations',
         id: observation.id,
         attributes: { reply: 'Some reply here' }
@@ -114,7 +114,7 @@ describe IssueToken do
 
     observations.each do |observation|
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
         {
           type: 'observations',
           id: observation.id,
@@ -143,7 +143,7 @@ describe IssueToken do
       )
 
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
         type: 'observations',
         id: observation.id,
         attributes: { reply: 'Some reply here' }
@@ -168,7 +168,7 @@ describe IssueToken do
     issue_token.observations.each do |observation|
       Timecop.travel 31.days.from_now
       api_update_issue_token(
-        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+        "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
         {
           type: 'observations',
           id: observation.id,
@@ -183,7 +183,7 @@ describe IssueToken do
     issue_token = IssueToken.where(issue: issue).first
     observation = create(:observation, issue: create(:basic_issue))
     api_update_issue_token(
-      "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+      "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
       {
         type: 'observations',
         id: observation.id,
@@ -198,7 +198,7 @@ describe IssueToken do
     observation = issue_token.observations.first
 
     api_update_issue_token(
-      "/issue_tokens/#{issue_token.token}/observations/#{observation.id}/reply",
+      "/issue_tokens/#{issue_token.token}/observations/#{observation.id}",
       type: 'observations',
       id: observation.id,
       attributes: { reply: 'Some reply here' }


### PR DESCRIPTION
Fixes https://github.com/bitex-la/storyboard/issues/2420

# This PR
Agregamos una validación para cuando se trata de responder una observación con espacios en blanco. Utilizo validación dependiente de contexto para que impacte solamente en el endpoint asociado, si no impactaría en todos los updates de `Observation` donde si es válido que la reply esté vacía.

Dejo link al ejemplo ya agregado en postman cuando responde un error por esta nueva validación:
https://bitex-la.postman.co/workspace/Bitex~b0ba98be-e217-4adf-8155-f674d4495f14/example/5758599-12576873-0f79-44eb-918c-c8b63bc9e97d